### PR TITLE
Compositions of finite index

### DIFF
--- a/ListExtras.v
+++ b/ListExtras.v
@@ -2,6 +2,8 @@ Require Import Coq.Bool.Bool Coq.Arith.Lt.
 Require Import List.
 Import ListNotations.
 
+Require Import Coq.Logic.FinFun.
+
 Require Import Casper.preamble.
 
 
@@ -741,6 +743,73 @@ Proof.
   generalize dependent n.
   induction l; intros [|n]; try reflexivity; simpl.
   apply IHl.
+Qed.
+  
+Lemma forall_finite
+  {index : Type}
+  {index_listing : list index}
+  (Hfinite_index : Full index_listing)
+  (P : index -> Prop)
+  : (forall n : index, P n) <-> Forall P index_listing.
+Proof.
+  split; intros.
+  - apply Forall_forall; intros. apply H.
+  - rewrite Forall_forall in H.
+    apply H. apply Hfinite_index.
+Qed.
+
+Lemma exists_finite
+  {index : Type}
+  {index_listing : list index}
+  (Hfinite_index : Full index_listing)
+  (P : index -> Prop)
+  : (exists n : index, P n) <-> List.Exists P index_listing.
+Proof.
+  split; intros.
+  - apply Exists_exists; intros.
+    destruct H as [n H].
+    exists n.
+    split; try assumption.
+    apply Hfinite_index.  
+  - rewrite Exists_exists in H.
+    destruct H as [n [_ H]].
+    exists n. assumption.
+Qed.
+
+Lemma Exists_dec
+  {A : Type}
+  (P : A -> Prop)
+  (l : list A)
+  (P_dec : forall a : A, {P a} + {~ P a})
+  : {List.Exists P l} + {~ List.Exists P l}
+  .
+Proof.
+  induction l.
+  - right. intro. inversion H.
+  - specialize (P_dec a).
+    destruct P_dec as [Pa | Pna].
+    + left. left. assumption.
+    + destruct IHl as [Pl | Pnl] .
+      * left. right. assumption.
+      * right. intro. inversion H; subst; contradiction.
+Qed.
+
+Lemma Forall_dec
+  {A : Type}
+  (P : A -> Prop)
+  (l : list A)
+  (P_dec : forall a : A, {P a} + {~ P a})
+  : {List.Forall P l} + {~ List.Forall P l}
+  .
+Proof.
+  induction l.
+  - left. constructor.
+  - specialize (P_dec a).
+    destruct P_dec as [Pa | Pna].
+    + destruct IHl as [Pl | Pnl] .
+      * left. constructor;  assumption.
+      * right. intro. inversion H; subst; contradiction.
+    + right. intro. inversion H; contradiction.
 Qed.
 
 (**

--- a/commute.v
+++ b/commute.v
@@ -1,3 +1,4 @@
+Require Import Coq.Logic.FinFun.
 Require Import Bool List Streams Logic.Epsilon.
 Import List Notations.
 From Casper 
@@ -84,14 +85,17 @@ Section CommuteIndexed.
 
   Context
     {CV : consensus_values}
-    {index : Set} `{Heqd : EqDec index}
+    {index : Set}
+    {index_listing : list index}
+    (finite_index : Listing index_listing)
+    `{Heqd : EqDec index}
     {message : Type} 
     {IT : index -> VLSM_type message}
     {IS : forall i : index, LSM_sig (IT i)}
     (IM : forall i : index, VLSM (IS i))
     (Hi : index)
-    (constraint : indexed_label IT -> indexed_state IT * option (indexed_proto_message _ _ IS) -> Prop)
-    (X := indexed_vlsm_constrained Hi IT IS IM constraint)
+    (constraint : indexed_label IT -> indexed_state IT * option (indexed_proto_message finite_index _ _ IS) -> Prop)
+    (X := indexed_vlsm_constrained finite_index Hi IT IS IM constraint)
     (ID : forall i : index, decision (IT i)).
     
   (* 3.2.2 Decision consistency *)
@@ -126,7 +130,7 @@ Section CommuteIndexed.
 
   Lemma final_and_consistent_implies_final : 
       final_and_consistent ->
-      forall i : index, final (indexed_vlsm_constrained_projection Hi _ _ IM constraint i) (ID i).
+      forall i : index, final (indexed_vlsm_constrained_projection finite_index Hi _ _ IM constraint i) (ID i).
 
   Proof.
     unfold final_and_consistent.
@@ -149,20 +153,23 @@ End CommuteIndexed.
 Section Estimators.
   Context
     {CV : consensus_values}
-    {index : Set} `{Heqd : EqDec index}
+    {index : Set}
+    {index_listing : list index}
+    (finite_index : Listing index_listing)
+    `{Heqd : EqDec index}
     {message : Type} 
     {IT : index -> VLSM_type message}
     (IS : forall i : index, LSM_sig (IT i))
     (IM : forall i : index, VLSM (IS i))
     (Hi : index)
-    (constraint : indexed_label IT -> indexed_state IT * option (indexed_proto_message _ _ IS) -> Prop)
-    (X := indexed_vlsm_constrained Hi _ IS IM constraint)
+    (constraint : indexed_label IT -> indexed_state IT * option (indexed_proto_message finite_index _ _ IS) -> Prop)
+    (X := indexed_vlsm_constrained finite_index Hi _ IS IM constraint)
     (ID : forall i : index, decision (IT i))
     (IE : forall i : index, Estimator (@state _ (IT i)) C).
 
   Definition decision_estimator_property
     (i : index)
-    (Xi := indexed_vlsm_constrained_projection Hi _ _ IM constraint i)
+    (Xi := indexed_vlsm_constrained_projection finite_index Hi _ _ IM constraint i)
     (Ei := @estimator _ _ (IE i))
     := forall
       (psigma : protocol_state Xi)
@@ -178,7 +185,7 @@ Section Estimators.
 
   Lemma decision_estimator_finality
     (i : index)
-    (Xi := indexed_vlsm_constrained_projection Hi _ _ IM constraint i)
+    (Xi := indexed_vlsm_constrained_projection finite_index Hi _ _ IM constraint i)
     : decision_estimator_property i -> final Xi (ID i).
   Proof.
     intros He tr n1 n2 s1 s2 c1 c2 Hs1 Hs2 Hc1 Hc2.

--- a/preamble.v
+++ b/preamble.v
@@ -1,4 +1,4 @@
-Require Import Reals Bool Relations RelationClasses List ListSet EqdepFacts ChoiceFacts ProofIrrelevance.
+Require Import Reals Bool Relations RelationClasses List ListSet EqdepFacts ChoiceFacts ProofIrrelevance Eqdep_dec.
 Import ListNotations.
 
 Tactic Notation "spec" hyp(H) := 
@@ -42,6 +42,17 @@ Qed.
 Class EqDec X :=
   eq_dec : forall x y : X, {x = y} + {x <> y}.
 
+(* https://coq.discourse.group/t/writing-equality-decision-that-reduces-dec-x-x-for-opaque-x/551/2 *)
+
+Lemma eq_dec_refl A (eq_dec : forall x y : A, {x = y} + {x <> y}) x :
+  eq_dec x x = left eq_refl.
+Proof.
+  destruct (eq_dec x x) as [|[]]; trivial.
+  f_equal.
+  now apply K_dec_type with (P := fun prf => prf = eq_refl).
+Qed.
+
+(*
 Lemma DepEqDec
   {X}
   (Heqd : EqDec X)
@@ -54,6 +65,7 @@ Proof.
   - left. subst. apply f_equal. apply proof_irrelevance.
   - right.  intros Heq. apply Hneq. inversion Heq. reflexivity.
 Qed.
+*)
 
 Lemma nat_eq_dec : EqDec nat.
 Proof.

--- a/vlsm.v
+++ b/vlsm.v
@@ -335,6 +335,8 @@ we define states and messages together as a property over a product type. *)
             ;   output : option proto_message
         }.
 
+      (* A finite protocol trace originating in a given state *)
+      
       Inductive finite_ptrace_from : state -> list in_state_out -> Prop :=
       | finite_ptrace_empty : forall (s : state), protocol_state_prop s -> finite_ptrace_from s []
       | finite_ptrace_extend : forall  (s : state) (tl : list in_state_out),
@@ -507,6 +509,8 @@ we define states and messages together as a property over a product type. *)
           rewrite list_prefix_nth; assumption.
       Qed.
 
+      (* An infinite protocol trace originating in a given state *)
+      
       CoInductive infinite_ptrace_from :
         state -> Stream in_state_out -> Prop :=
       | infinite_ptrace_extend : forall  (s : state) (tl : Stream in_state_out),
@@ -787,6 +791,8 @@ we define states and messages together as a property over a product type. *)
           rewrite Htr_r0 in Hextend.
           apply Hextend.
           Qed.
+
+      (* protocol states/messages correspond to protocol traces *)
 
       Lemma protocol_is_trace
             (som' : state * option proto_message)


### PR DESCRIPTION
I added a finite index constraint to the vlsm composition (indexed_vlsm).
This allows us to lift decidability results from the individual vlsms to the composed one.
In the pars we were cheating by using first-order excluded_middle instead of proper decidability.