### PR TITLE
Estimator property implies finality.

### DIFF
--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -848,6 +848,19 @@ Require Import Lib.Preamble Lib.ListExtras.
       exists (tr : list in_state_out),
         finite_ptrace_from first tr /\
         last (List.map destination tr) first = second.
+        
+    Lemma in_futures_reflexive
+      (pfirst: protocol_state)
+      : in_futures pfirst pfirst.
+      
+      Proof.
+      unfold in_futures.
+      exists [].
+      split.
+      - apply finite_ptrace_empty.
+        destruct pfirst. assumption.
+       - simpl. auto.
+      Qed.
 
     Lemma in_futures_witness
       (pfirst psecond : protocol_state)


### PR DESCRIPTION
- Added proof that the estimator property ((1) in pg 23) implies finality.
- Changed the definition of finality into an equivalent version that plays better with the estimator property definition. Ideally, this alteration will also be reflected in the document, but we can also prove the equivalence later on, if it's necessary.