### PR TITLE
Byzantine trace definitions

### DIFF
--- a/VLSM/ByzantineFaults.v
+++ b/VLSM/ByzantineFaults.v
@@ -26,13 +26,8 @@ Proof.
     destruct Hbyz as [T' [S' [M' Htr]]].
     simpl in Htr.
     specialize
-        (@proj_pre_loaded_incl
-            message
-            _
-            binary_index_dec
+        (proj_pre_loaded_incl
             first
-            _
-            _
             (binary_IM M M')
             free_constraint
             first
@@ -136,7 +131,7 @@ Context
         (s : @state _ T)
         (init := proj1_sig (@s0 _ _ (sign Alt)))
         : @state _ (type Alt)
-        := @state_update message binary_index binary_index_dec binary_IT init first s.
+        := @state_update _ _ binary_index_dec binary_IT init first s.
 
     Lemma proj_alt_protocol_state
         (sj : state)

--- a/VLSM/ByzantineFaults.v
+++ b/VLSM/ByzantineFaults.v
@@ -3,6 +3,343 @@ Require Import FinFun Streams.
 From CasperCBC   
 Require Import Lib.Preamble VLSM.Common VLSM.Composition.
 
+Section ByzantineTraces.
+Context
+    {message : Type}
+    {T : VLSM_type message}
+    {S : LSM_sig T}
+    (M : VLSM S)
+    .
+
+Definition byzantine_trace_prop
+    (tr : @Trace _ T) :=
+    exists (T' : VLSM_type message) (S' : LSM_sig T') (M' : VLSM S')
+        (Proj := binary_free_composition_fst M M'),
+        protocol_trace_prop Proj tr.
+
+Lemma byzantine_pre_loaded
+    (PreLoaded := pre_loaded_vlsm M)
+    (tr : @Trace _ T)
+    (Hbyz : byzantine_trace_prop tr)
+    : protocol_trace_prop PreLoaded tr.
+Proof.
+    destruct Hbyz as [T' [S' [M' Htr]]].
+    simpl in Htr.
+    specialize
+        (@proj_pre_loaded_incl
+            message
+            _
+            binary_index_dec
+            first
+            _
+            _
+            (binary_IM M M')
+            free_constraint
+            first
+            tr
+            Htr
+        ); intros Htr'.
+    assumption.
+Qed.
+    
+
+Definition all_messages_type : VLSM_type message :=
+    {| label := message
+     ; state := unit
+    |}.
+
+Definition all_messages_sig
+    (inhm : message)
+    : LSM_sig all_messages_type
+    :=
+    {| initial_state_prop := fun s => True
+     ; initial_message_prop := fun m => False
+     ; s0 := exist (fun s: @state _ all_messages_type => True) tt I
+     ; m0 := inhm
+     ; l0 := inhm
+    |}.
+
+Definition all_messages_transition
+    (l : @label _ all_messages_type)
+    (som : @state _ all_messages_type * option message)
+    : @state _ all_messages_type * option message
+    := (tt, Some l)
+    .
+
+Definition all_messages_valid
+    (l : @label _ all_messages_type)
+    (som : @state _ all_messages_type * option message)
+    : Prop
+    := True.
+
+Definition all_messages_vlsm
+    (inhm : message)
+    : VLSM (all_messages_sig inhm)
+    :=
+    {| transition := all_messages_transition
+     ; valid := all_messages_valid
+    |}
+    .
+
+Definition byzantine_trace_prop_alt
+    (tr : @Trace _ T)
+    (Proj := binary_free_composition_fst M (all_messages_vlsm m0))
+    :=
+    protocol_trace_prop Proj tr.
+
+Lemma byzantine_alt_byzantine
+    (tr : @Trace _ T)
+    (Halt : byzantine_trace_prop_alt tr)
+    : byzantine_trace_prop tr.
+Proof.
+    exists all_messages_type.
+    exists (all_messages_sig m0).
+    exists (all_messages_vlsm m0).
+    assumption.
+Qed.
+
+Section pre_loaded_byzantine_alt.
+Context
+    (PreLoaded := pre_loaded_vlsm M)
+    (Proj := binary_free_composition_fst M (all_messages_vlsm m0))
+    (Alt := binary_free_composition M (all_messages_vlsm m0))
+    .
+
+    Lemma alt_protocol_message
+        (m : message)
+        : protocol_message_prop Alt m.
+    Proof.
+        remember (proj1_sig (@s0 _ _ (sign Alt))) as s.
+        exists s.
+        assert (Ht : @transition _ _ _ Alt (existT _ second m) (s, None) = (s, Some m)).
+        { simpl.
+          f_equal.
+          apply state_update_id.
+          subst. reflexivity.
+        }
+        rewrite <- Ht.
+        assert (Hps : protocol_prop Alt (s, None))
+            by (subst; apply protocol_initial_state). 
+        apply protocol_generated with None s; try assumption.
+        split; exact I.
+    Qed.
+
+    Lemma alt_proj_protocol_message
+        (m : message)
+        : protocol_message_prop Proj m.
+    Proof.
+        apply protocol_message_projection.
+        apply alt_protocol_message.
+    Qed.
+
+    Definition lifted_alt_state
+        (s : @state _ T)
+        (init := proj1_sig (@s0 _ _ (sign Alt)))
+        : @state _ (type Alt)
+        := @state_update message binary_index binary_index_dec binary_IT init first s.
+
+    Lemma proj_alt_protocol_state
+        (sj : state)
+        (om : option message)
+        (Hp : protocol_prop Proj (sj, om))
+        : protocol_state_prop Alt (lifted_alt_state sj).
+    Proof.
+      remember (sj, om) as sjom.
+      generalize dependent om. generalize dependent sj.
+      induction Hp; intros; inversion Heqsjom; subst; clear Heqsjom.
+      - assert (Hinit : @initial_state_prop _ _ (sign Alt) (lifted_alt_state s)).
+        { intros [|]; try exact I.
+          unfold lifted_alt_state.
+          rewrite state_update_eq. unfold s. destruct is. assumption.
+        }
+        remember (exist (@initial_state_prop _ _ (sign Alt)) (lifted_alt_state s) Hinit) as six.
+        replace (lifted_alt_state s) with (proj1_sig six); try (subst; reflexivity).
+        exists None.
+        apply (protocol_initial_state Alt).
+      - assert (Hinit : @initial_state_prop _ _ (sign Alt) (lifted_alt_state s)).
+        { intros [|]; try exact I.
+          unfold lifted_alt_state.
+          rewrite state_update_eq. unfold s. destruct s0. assumption.
+        }
+        remember (exist (@initial_state_prop _ _ (sign Alt)) (lifted_alt_state s) Hinit) as six.
+        replace (lifted_alt_state s) with (proj1_sig six); try (subst; reflexivity).
+        exists None.
+        apply (protocol_initial_state Alt).
+      - destruct Hv as [[psX HpsX] [opm [Heqs [Heqopm Hv]]]].
+        simpl in Heqs. rewrite <- Heqs in *. clear Heqs.
+        specialize (IHHp1 (psX first) _om eq_refl).
+        destruct Hv as [Hv _].
+        simpl in Hv.
+        rewrite Heqopm in Hv.
+        remember (@transition _ _ _ Alt (existT _ first l) ((lifted_alt_state (psX first)), om)) as xsom'.
+        destruct xsom' as [xs' om'].
+        destruct IHHp1 as [_omX Hlift].
+        exists om'.
+        replace (lifted_alt_state sj) with xs'.
+        + rewrite Heqxsom'.
+          assert (Hsj : exists sj : state, protocol_prop Proj (sj, om))
+            by (exists _s; assumption).
+          specialize
+            (@protocol_message_projection_rev
+                _ _ binary_index_dec first _ _
+                (binary_IM M (all_messages_vlsm m0))
+                free_constraint
+                first
+                om
+                Hsj
+            ); intros [_sX HpmX].
+          apply (protocol_generated Alt) with _omX _sX; try assumption.
+          split; try exact I.
+          assumption.
+        + simpl in Heqxsom'. 
+          unfold lifted_alt_state at 1 in Heqxsom'.
+          rewrite state_update_eq in Heqxsom'.
+          rewrite H0 in Heqxsom'.
+          inversion Heqxsom'; subst.
+          unfold lifted_alt_state.
+          apply state_update_twice.
+    Qed.
+
+    Lemma pre_loaded_alt_protocol_state
+        (sj : state)
+        (om : option message)
+        (Hp : protocol_prop PreLoaded (sj, om))
+        : protocol_state_prop Proj sj.
+    Proof.
+        remember (sj, om) as sjom.
+        generalize dependent om. generalize dependent sj.
+        induction Hp; intros; inversion Heqsjom; subst; clear Heqsjom.
+        - exists None. apply (protocol_initial_state Proj).
+        - exists None. apply (protocol_initial_state Proj).
+        - specialize (IHHp1 s _om eq_refl).
+          specialize (IHHp2 _s om eq_refl).
+          exists om0.
+          replace
+            (@pair
+                (@state message (@binary_IT message T all_messages_type first))
+                (option message)
+                sj
+                om0
+            ) with (@transition _ _ _ Proj l (s, om)).
+          destruct IHHp1 as [_omp Hpsp].
+          specialize (proj_alt_protocol_state s _omp Hpsp)
+          ; intro HpsX.
+          destruct om as [m|].
+          + destruct (alt_proj_protocol_message m) as [_smp Hpmp].
+            apply (protocol_generated Proj) with _omp _smp
+            ; try assumption.
+            exists (exist _ (lifted_alt_state s) HpsX).
+            specialize (alt_protocol_message m); intro HpmX.
+            exists (Some (exist _ m HpmX)).
+            repeat split; assumption.
+          + apply (protocol_generated Proj) with _omp (proj1_sig (@s0 _ _ (sign Proj)))
+            ; try assumption.
+            * apply protocol_initial_state.
+            * exists (exist _ (lifted_alt_state s) HpsX).
+              exists None.
+              repeat split; assumption.
+    Qed.
+ 
+    Lemma pre_loaded_alt_verbose_valid_protocol_transition
+        (l : label)
+        (is os : state)
+        (iom oom : option message)
+        (Ht : verbose_valid_protocol_transition PreLoaded l is os iom oom)
+        : verbose_valid_protocol_transition Proj l is os iom oom
+        .
+    Proof.
+        destruct Ht as [[_om Hps] [[_s Hpm] [Hv Ht]]].
+        repeat (split; try assumption).
+        - apply pre_loaded_alt_protocol_state with _om.
+          assumption.
+        - destruct iom as [im|].
+          + apply alt_proj_protocol_message.
+          + exists (proj1_sig s0). apply (protocol_initial_state Proj s0).
+        - specialize (pre_loaded_alt_protocol_state is _om Hps)
+          ; intros [_ism Hpsp].
+          specialize (proj_alt_protocol_state is _ism Hpsp)
+          ; intro Hps_alt.
+          exists (exist _ (lifted_alt_state is) Hps_alt).
+          destruct iom as [im|].
+          + specialize (alt_protocol_message im); intro Hpim_alt.
+            exists (Some (exist _ im Hpim_alt)).
+            repeat split; assumption.
+          + exists None.
+            repeat split; assumption.
+    Qed.
+
+    Lemma pre_loaded_alt_finite_ptrace
+        (s : state)
+        (ls : list in_state_out)
+        (Hpxt : finite_ptrace_from PreLoaded s ls)
+        : finite_ptrace_from Proj s ls
+        .
+    Proof.
+        induction Hpxt.
+        - constructor.
+          destruct H as [m H].
+          apply pre_loaded_alt_protocol_state with m. assumption.
+        - constructor; try assumption.
+          apply pre_loaded_alt_verbose_valid_protocol_transition.
+          assumption.
+    Qed.
+
+    Lemma pre_loaded_alt_infinite_ptrace
+        (s : state)
+        (ls : Stream in_state_out)
+        (Hpxt : infinite_ptrace_from PreLoaded s ls)
+        : infinite_ptrace_from Proj s ls
+        .
+    Proof.
+        generalize dependent ls. generalize dependent s.
+        cofix H.
+        intros s [[l input destination output] ls] Hx.
+        inversion Hx; subst.
+        specialize (H destination ls H3).
+        constructor; try assumption.
+        apply pre_loaded_alt_verbose_valid_protocol_transition.
+        assumption.
+    Qed.
+
+    Lemma pre_loaded_alt_incl
+        : VLSM_incl PreLoaded Proj
+        .
+    Proof.
+        intros [s ls| s ss]; simpl; intros [Hxt Hinit].  
+        - apply pre_loaded_alt_finite_ptrace in Hxt.
+          split; try assumption.
+        - apply pre_loaded_alt_infinite_ptrace in Hxt.
+          split; try assumption.
+    Qed.
+
+    Lemma alt_pre_loaded_incl
+        : VLSM_incl Proj PreLoaded
+        .
+    Proof.
+        intros t Hpt.
+        apply byzantine_pre_loaded.
+        apply byzantine_alt_byzantine.
+        assumption.
+    Qed.
+
+End pre_loaded_byzantine_alt.
+
+Lemma byzantine_alt_byzantine_iff
+    (tr : @Trace _ T)
+    : byzantine_trace_prop_alt tr <-> byzantine_trace_prop tr.
+Proof.
+    split; intros.
+    - apply byzantine_alt_byzantine; assumption.
+    - apply pre_loaded_alt_incl.
+      apply byzantine_pre_loaded.
+      assumption.
+Qed.
+
+
+End ByzantineTraces.
+
+Section validating.
+
 Context
     {message : Type}
     {index : Type}
@@ -116,12 +453,12 @@ Proof.
       repeat (split; try assumption).
 Qed.
 
-Section message_full_validating_proj.
+Section pre_loaded_validating_proj.
     Context
         (i : index)
         (Hvalidating : validating_condition i)
         (Proj := indexed_vlsm_constrained_projection i0 IM constraint i)
-        (Full := message_full_vlsm (IM i))
+        (PreLoaded := pre_loaded_vlsm (IM i))
         .
 
     Lemma validating_proj_protocol_message
@@ -138,18 +475,16 @@ Section message_full_validating_proj.
         apply protocol_message_projection. assumption.
     Qed.
 
-
-
-    Lemma _message_full_validating_proj_protocol_state
+    Lemma _pre_loaded_validating_proj_protocol_state
         (som : state * option message)
-        (Hps : protocol_prop Full som)
+        (Hps : protocol_prop PreLoaded som)
         : protocol_state_prop Proj (fst som).
     Proof.
         induction Hps.
         - exists None. apply (protocol_initial_state Proj is).
         - exists None. apply (protocol_initial_state Proj (@VLSM.Common.s0 _ _ (IS i))).
         - destruct
-            (@transition message (IT i) (@message_full_vlsm_sig message (IT i) (IS i) (IM i)) Full l
+            (@transition message (IT i) (@pre_loaded_vlsm_sig message (IT i) (IS i) (IM i)) PreLoaded l
                 (@pair (@state message (IT i)) (option message) s om)) as [s' om'] eqn:Ht.
           exists om'. simpl. rewrite <- Ht.
           clear IHHps2. simpl in IHHps1. clear Hps1 Hps2 _s _om.
@@ -163,29 +498,29 @@ Section message_full_validating_proj.
             * apply Hvalidating. assumption.
     Qed.
 
-    Lemma message_full_validating_proj_protocol_state
+    Lemma pre_loaded_validating_proj_protocol_state
         (s : state)
         (om : option message)
-        (Hps : protocol_prop Full (s,om))
+        (Hps : protocol_prop PreLoaded (s,om))
         : protocol_state_prop Proj s.
     Proof.
         remember (s, om) as som. 
         assert (Hs : s = fst som) by (subst; reflexivity).
-        rewrite Hs. apply _message_full_validating_proj_protocol_state.
+        rewrite Hs. apply _pre_loaded_validating_proj_protocol_state.
         assumption.
     Qed.
 
-    Lemma message_full_validating_proj_verbose_valid_protocol_transition
+    Lemma pre_loaded_validating_proj_verbose_valid_protocol_transition
         (l : label)
         (is os : state)
         (iom oom : option message)
-        (Ht : verbose_valid_protocol_transition Full l is os iom oom)
+        (Ht : verbose_valid_protocol_transition PreLoaded l is os iom oom)
         : verbose_valid_protocol_transition Proj l is os iom oom
         .
     Proof.
         destruct Ht as [[_om Hps] [[_s Hpm] [Hv Ht]]].
         repeat (split; try assumption).
-        - apply message_full_validating_proj_protocol_state with _om.
+        - apply pre_loaded_validating_proj_protocol_state with _om.
           assumption.
         - destruct iom as [im|].
           + apply validating_proj_protocol_message with l is. assumption.
@@ -193,26 +528,26 @@ Section message_full_validating_proj.
         - apply Hvalidating. assumption.
     Qed.
 
-    Lemma message_full_validating_proj_finite_ptrace
+    Lemma pre_loaded_validating_proj_finite_ptrace
         (s : state)
         (ls : list in_state_out)
-        (Hpxt : finite_ptrace_from Full s ls)
+        (Hpxt : finite_ptrace_from PreLoaded s ls)
         : finite_ptrace_from Proj s ls
         .
     Proof.
         induction Hpxt.
         - constructor.
           destruct H as [m H].
-          apply message_full_validating_proj_protocol_state with m. assumption.
+          apply pre_loaded_validating_proj_protocol_state with m. assumption.
         - constructor; try assumption.
-          apply message_full_validating_proj_verbose_valid_protocol_transition.
+          apply pre_loaded_validating_proj_verbose_valid_protocol_transition.
           assumption.
     Qed.
 
-    Lemma message_full_validating_proj_infinite_ptrace
+    Lemma pre_loaded_validating_proj_infinite_ptrace
         (s : state)
         (ls : Stream in_state_out)
-        (Hpxt : infinite_ptrace_from Full s ls)
+        (Hpxt : infinite_ptrace_from PreLoaded s ls)
         : infinite_ptrace_from Proj s ls
         .
     Proof.
@@ -222,28 +557,30 @@ Section message_full_validating_proj.
         inversion Hx; subst.
         specialize (H destination ls H3).
         constructor; try assumption.
-        apply message_full_validating_proj_verbose_valid_protocol_transition.
+        apply pre_loaded_validating_proj_verbose_valid_protocol_transition.
         assumption.
     Qed.
 
-    Lemma message_full_validating_proj_incl
-        : VLSM_incl Full Proj
+    Lemma pre_loaded_validating_proj_incl
+        : VLSM_incl PreLoaded Proj
         .
     Proof.
         intros [s ls| s ss]; simpl; intros [Hxt Hinit].  
-        - apply message_full_validating_proj_finite_ptrace in Hxt.
+        - apply pre_loaded_validating_proj_finite_ptrace in Hxt.
           split; try assumption.
-        - apply message_full_validating_proj_infinite_ptrace in Hxt.
+        - apply pre_loaded_validating_proj_infinite_ptrace in Hxt.
           split; try assumption.
     Qed.
 
-    Lemma message_full_validating_proj_eq
-        : VLSM_eq Full Proj
+    Lemma pre_loaded_validating_proj_eq
+        : VLSM_eq PreLoaded Proj
         .
     Proof.
         split.
-        - apply message_full_validating_proj_incl.
-        - apply proj_message_full_incl.
+        - apply pre_loaded_validating_proj_incl.
+        - apply proj_pre_loaded_incl.
     Qed.
 
-End message_full_validating_proj.
+End pre_loaded_validating_proj.
+
+End validating.

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -1359,7 +1359,7 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
 
   End VLSM_equality.
 
-  Definition message_full_vlsm_sig
+  Definition pre_loaded_vlsm_sig
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
@@ -1373,18 +1373,18 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
      ; l0 := @l0 _ _ Sig
     |}.
 
-  Definition message_full_vlsm
+  Definition pre_loaded_vlsm
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
     (X : VLSM Sig)
-    : VLSM (message_full_vlsm_sig X)
+    : VLSM (pre_loaded_vlsm_sig X)
     := 
     {| transition := @transition _ _ _ X
      ; valid := @valid _ _ _ X
     |}.
 
-  Lemma message_full_protocol_prop
+  Lemma pre_loaded_protocol_prop
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
@@ -1392,18 +1392,18 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
     (s : state)
     (om : option message)
     (Hps : protocol_prop X (s, om))
-    : protocol_prop (message_full_vlsm X) (s, om).
+    : protocol_prop (pre_loaded_vlsm X) (s, om).
   Proof.
     induction Hps.
-    - apply (protocol_initial_state (message_full_vlsm X) is).
+    - apply (protocol_initial_state (pre_loaded_vlsm X) is).
     - destruct im as [m Him]. simpl in om0. clear Him.
-      assert (Him : @initial_message_prop _ _ (message_full_vlsm_sig X) m)
+      assert (Him : @initial_message_prop _ _ (pre_loaded_vlsm_sig X) m)
         by exact I.
-      apply (protocol_initial_message (message_full_vlsm X) (exist _ m Him)).
-    - apply (protocol_generated (message_full_vlsm X)) with _om _s; assumption.
+      apply (protocol_initial_message (pre_loaded_vlsm X) (exist _ m Him)).
+    - apply (protocol_generated (pre_loaded_vlsm X)) with _om _s; assumption.
   Qed.
 
-  Lemma message_full_verbose_valid_protocol_transition
+  Lemma pre_loaded_verbose_valid_protocol_transition
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
@@ -1412,16 +1412,16 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
     (is os : state)
     (iom oom : option message)
     (Ht : verbose_valid_protocol_transition X l is os iom oom)
-    : verbose_valid_protocol_transition (message_full_vlsm X) l is os iom oom
+    : verbose_valid_protocol_transition (pre_loaded_vlsm X) l is os iom oom
     .
   Proof.
     destruct Ht as [[_om Hps] [[_s Hpm] [Hv Ht]]].
     repeat (split; try assumption).
-    - exists _om. apply message_full_protocol_prop. assumption.
-    - exists _s. apply message_full_protocol_prop. assumption.
+    - exists _om. apply pre_loaded_protocol_prop. assumption.
+    - exists _s. apply pre_loaded_protocol_prop. assumption.
   Qed.
 
-  Lemma message_full_finite_ptrace
+  Lemma pre_loaded_finite_ptrace
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
@@ -1429,19 +1429,19 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
     (s : state)
     (ls : list in_state_out)
     (Hpxt : finite_ptrace_from X s ls)
-    : finite_ptrace_from (message_full_vlsm X) s ls
+    : finite_ptrace_from (pre_loaded_vlsm X) s ls
     .
   Proof.
     induction Hpxt.
     - constructor.
       destruct H as [m H].
-      apply message_full_protocol_prop in H.
+      apply pre_loaded_protocol_prop in H.
       exists m. assumption.
     - constructor; try assumption.
-      apply message_full_verbose_valid_protocol_transition. assumption.
+      apply pre_loaded_verbose_valid_protocol_transition. assumption.
   Qed.
 
-  Lemma message_full_infinite_ptrace
+  Lemma pre_loaded_infinite_ptrace
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
@@ -1449,7 +1449,7 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
     (s : state)
     (ls : Stream in_state_out)
     (Hpxt : infinite_ptrace_from X s ls)
-    : infinite_ptrace_from (message_full_vlsm X) s ls
+    : infinite_ptrace_from (pre_loaded_vlsm X) s ls
     .
   Proof.
     generalize dependent ls. generalize dependent s.
@@ -1458,23 +1458,23 @@ Require Import Lib.Preamble Lib.ListExtras Lib.StreamExtras.
     inversion Hx; subst.
     specialize (H destination ls H3).
     constructor; try assumption.
-    apply message_full_verbose_valid_protocol_transition.
+    apply pre_loaded_verbose_valid_protocol_transition.
     assumption.
   Qed.
 
-  Lemma vlsm_incl_message_full_vlsm
+  Lemma vlsm_incl_pre_loaded_vlsm
     {message : Type}
     {vtype : VLSM_type message}
     {Sig : LSM_sig vtype}
     (X : VLSM Sig)
-    (Full := message_full_vlsm X)
-    : VLSM_incl X Full
+    (PreLoaded := pre_loaded_vlsm X)
+    : VLSM_incl X PreLoaded
     .
   Proof.
     intros [s ls| s ss]; simpl; intros [Hxt Hinit].  
-    - apply message_full_finite_ptrace in Hxt.
+    - apply pre_loaded_finite_ptrace in Hxt.
       split; try assumption.
-    - apply message_full_infinite_ptrace in Hxt.
+    - apply pre_loaded_infinite_ptrace in Hxt.
       split; try assumption.
   Qed.
 

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -66,6 +66,34 @@ Section indexing.
       rewrite eq_dec_refl. reflexivity.
     Qed.
 
+    Lemma state_update_id
+               (s : indexed_state)
+               (i : index)
+               (si : @state message (IT i))
+               (Heq : s i = si)
+      : state_update s i si = s.
+    Proof.
+      apply functional_extensionality_dep_good.
+      intro j.
+      destruct (eq_dec j i).
+      - subst. apply state_update_eq.
+      - apply state_update_neq. assumption.
+    Qed.
+
+    Lemma state_update_twice
+               (s : indexed_state)
+               (i : index)
+               (si si': @state message (IT i))
+      : state_update (state_update s i si) i si' = state_update s i si'.
+    Proof.
+      apply functional_extensionality_dep_good.
+      intro j.
+      destruct (eq_dec j i).
+      - subst. rewrite state_update_eq. symmetry. apply state_update_eq.
+      - repeat rewrite state_update_neq; try assumption.
+        reflexivity.
+    Qed.
+
   End indexed_type.
   
   Section indexed_sig.
@@ -180,6 +208,52 @@ Section indexing.
       :=
         indexed_vlsm_constrained free_constraint
     .
+
+    Lemma protocol_prop_indexed_free_lift
+      (S := (indexed_sig i0 IS))
+      (j : index)
+      (sj : @state _ (IT j))
+      (om : option message)
+      (Hp : protocol_prop (IM j) (sj, om))
+      (s0X := proj1_sig (@s0 _ _ S))
+      : protocol_prop indexed_vlsm_free ((state_update IT s0X j sj), om)
+      .
+    Proof.
+      remember (sj, om) as sjom.
+      generalize dependent om. generalize dependent sj.
+      induction Hp; intros; inversion Heqsjom; subst; clear Heqsjom.
+      - assert (Hinit : @initial_state_prop _ _ S (state_update IT s0X j s)).
+        { intro i.
+          destruct (eq_dec i j).
+          - subst; rewrite state_update_eq. unfold s. destruct is. assumption.
+          - rewrite state_update_neq; try assumption.
+            destruct (@s0 _ _ S) as [s00 Hinit].
+            unfold s0X; clear s0X; simpl.
+            apply Hinit.
+        }
+        remember (exist (@initial_state_prop _ _ S) (state_update IT s0X j s) Hinit) as six.
+        replace (state_update IT s0X j s) with (proj1_sig six); try (subst; reflexivity).
+        apply (protocol_initial_state indexed_vlsm_free).
+      - assert (Hinit : @initial_message_prop _ _ S (proj1_sig im)).
+        { exists j. exists im. reflexivity. }
+        replace (state_update IT s0X j s) with s0X
+        ; try (symmetry; apply state_update_id; reflexivity).
+        unfold s in *; unfold om in *; clear s om.
+        destruct im as [m _H]; simpl in *; clear _H.
+        remember (exist (@initial_message_prop _ _ S) m Hinit) as im.
+        replace m with (proj1_sig im); try (subst; reflexivity).
+        apply (protocol_initial_message indexed_vlsm_free).
+      - specialize (IHHp1 s _om eq_refl).
+        specialize (IHHp2 _s om eq_refl).
+        replace (state_update IT s0X j sj, om0) with (@transition _ _ _ indexed_vlsm_free (existT _ j l) (state_update IT s0X j s, om)).
+        + apply (protocol_generated indexed_vlsm_free) with _om (state_update IT s0X j _s)
+          ; try assumption.
+          split; try exact I.
+          simpl. rewrite state_update_eq. assumption.
+        + simpl. rewrite state_update_eq. rewrite H0.
+          f_equal.
+          apply state_update_twice.
+    Qed.
 
   End indexed_vlsm.
 
@@ -341,6 +415,55 @@ Section projections.
         specialize (Hinit (exist _ im Hini)); simpl in Hinit.
         assumption.
       - apply (protocol_initial_state Proj).
+    Qed.
+
+    Lemma projection_valid_protocol_transition
+      (lj : label)
+      (ps : @protocol_state _ _ _ X)
+      (opm : option (@protocol_message _ _ _ X))
+      (sj := (proj1_sig ps) j)
+      (omj := option_map (@proj1_sig _ _) opm)
+      (Hv : protocol_valid X (existT _ j lj) (ps, opm))
+      : protocol_prop X (@transition _ _ _ X (existT _ j lj) (proj1_sig ps, omj))
+      .
+    Proof.
+      destruct ps as [psX HpsX].
+      simpl in sj. unfold sj in *. clear sj.
+      destruct HpsX as [_omX HpsX].
+      destruct opm as [[pmX [_sX HpmX]]|]
+      ; simpl in omj; unfold omj in *; clear omj.
+      - apply (protocol_generated X) with _omX _sX; assumption.
+      - apply (protocol_generated X) with _omX (proj1_sig (@s0 _ _ S))
+        ; try assumption.
+        apply (protocol_initial_state X).
+    Qed.
+
+    Lemma protocol_message_projection_rev
+      (iom : option message)
+      (Hpmj: exists sj : state, protocol_prop Proj (sj, iom))
+      : exists sx : state, protocol_prop X (sx, iom)
+      .
+    Proof.
+      destruct Hpmj as [sj Hpmj].
+      inversion Hpmj; subst.
+      - exists (proj1_sig (@s0 _ _ S)).
+        apply (protocol_initial_state X).
+      - destruct im as [im Him].
+        unfold om in *; simpl in *; clear om.
+        destruct Him as [[m Hpm] Heq].
+        subst; assumption.
+      - destruct Hv as [psX [opm [Heqs [Heqopm Hv]]]].
+        simpl in Heqs. rewrite <- Heqs in *. clear Heqs.
+        specialize (projection_valid_protocol_transition l psX opm Hv)
+        ; intro HpsX'.
+        rewrite Heqopm in HpsX'.
+        remember (@transition _ _ _ X (existT (fun n : index => label) j l) (proj1_sig psX, om)) as som'.
+        destruct som' as [s' om'].
+        exists s'.
+        simpl in Heqsom'.
+        rewrite H0 in Heqsom'.
+        inversion Heqsom'; subst.
+        assumption.
     Qed.
 
 (** 2.4.4.1 Projection friendly composition constraints **)
@@ -832,62 +955,62 @@ Section projections.
         assumption.
     Qed.
 
-    Lemma proj_message_full_protocol_prop
-      (Full := message_full_vlsm (IM j))
+    Lemma proj_pre_loaded_protocol_prop
+      (PreLoaded := pre_loaded_vlsm (IM j))
       (s : state)
       (om : option message)
       (Hps : protocol_prop Proj (s, om))
-      : protocol_prop Full (s, om).
+      : protocol_prop PreLoaded (s, om).
     Proof.
       induction Hps.
-      - apply (protocol_initial_state Full is).
+      - apply (protocol_initial_state PreLoaded is).
       - destruct im as [m Him]. simpl in om0. clear Him.
-        assert (Him : @initial_message_prop _ _ (message_full_vlsm_sig X) m)
+        assert (Him : @initial_message_prop _ _ (pre_loaded_vlsm_sig X) m)
           by exact I.
-        apply (protocol_initial_message Full (exist _ m Him)).
-      - apply (protocol_generated Full) with _om _s; try assumption.
+        apply (protocol_initial_message PreLoaded (exist _ m Him)).
+      - apply (protocol_generated PreLoaded) with _om _s; try assumption.
         apply composite_protocol_valid_implies_valid. assumption.
     Qed.
 
-    Lemma proj_message_full_verbose_valid_protocol_transition
-      (Full := message_full_vlsm (IM j))
+    Lemma proj_pre_loaded_verbose_valid_protocol_transition
+      (PreLoaded := pre_loaded_vlsm (IM j))
       (l : label)
       (is os : state)
       (iom oom : option message)
       (Ht : verbose_valid_protocol_transition Proj l is os iom oom)
-      : verbose_valid_protocol_transition Full l is os iom oom
+      : verbose_valid_protocol_transition PreLoaded l is os iom oom
       .
     Proof.
       destruct Ht as [[_om Hps] [[_s Hpm] [Hv Ht]]].
       repeat (split; try assumption).
-      - exists _om. apply proj_message_full_protocol_prop. assumption.
-      - exists _s. apply proj_message_full_protocol_prop. assumption.
+      - exists _om. apply proj_pre_loaded_protocol_prop. assumption.
+      - exists _s. apply proj_pre_loaded_protocol_prop. assumption.
       - apply composite_protocol_valid_implies_valid. assumption.
     Qed.
 
-    Lemma proj_message_full_finite_ptrace
-      (Full := message_full_vlsm (IM j))
+    Lemma proj_pre_loaded_finite_ptrace
+      (PreLoaded := pre_loaded_vlsm (IM j))
       (s : state)
       (ls : list in_state_out)
       (Hpxt : finite_ptrace_from Proj s ls)
-      : finite_ptrace_from Full s ls
+      : finite_ptrace_from PreLoaded s ls
       .
     Proof.
       induction Hpxt.
       - constructor.
         destruct H as [m H].
-        apply proj_message_full_protocol_prop in H.
+        apply proj_pre_loaded_protocol_prop in H.
         exists m. assumption.
       - constructor; try assumption.
-        apply proj_message_full_verbose_valid_protocol_transition. assumption.
+        apply proj_pre_loaded_verbose_valid_protocol_transition. assumption.
     Qed.
 
-    Lemma proj_message_full_infinite_ptrace
-      (Full := message_full_vlsm (IM j))
+    Lemma proj_pre_loaded_infinite_ptrace
+      (PreLoaded := pre_loaded_vlsm (IM j))
       (s : state)
       (ls : Stream in_state_out)
       (Hpxt : infinite_ptrace_from Proj s ls)
-      : infinite_ptrace_from Full s ls
+      : infinite_ptrace_from PreLoaded s ls
       .
     Proof.
       generalize dependent ls. generalize dependent s.
@@ -896,19 +1019,19 @@ Section projections.
       inversion Hx; subst.
       specialize (H destination ls H3).
       constructor; try assumption.
-      apply proj_message_full_verbose_valid_protocol_transition.
+      apply proj_pre_loaded_verbose_valid_protocol_transition.
       assumption.
     Qed.
 
-    Lemma proj_message_full_incl
-      (Full := message_full_vlsm (IM j))
-      : VLSM_incl Proj Full
+    Lemma proj_pre_loaded_incl
+      (PreLoaded := pre_loaded_vlsm (IM j))
+      : VLSM_incl Proj PreLoaded
       .
     Proof.
       intros [s ls| s ss]; simpl; intros [Hxt Hinit].  
-      - apply proj_message_full_finite_ptrace in Hxt.
+      - apply proj_pre_loaded_finite_ptrace in Hxt.
         split; try assumption.
-      - apply proj_message_full_infinite_ptrace in Hxt.
+      - apply proj_pre_loaded_infinite_ptrace in Hxt.
         split; try assumption.
     Qed.
 
@@ -925,6 +1048,7 @@ Section free_projections.
           {IT : index -> VLSM_type message}
           {IS : forall i : index, LSM_sig (IT i)}
           (IM : forall n : index, VLSM (IS n))
+          (X := indexed_vlsm_free i0 IM)
           .
 
   Definition indexed_vlsm_free_projection_sig
@@ -938,4 +1062,59 @@ Section free_projections.
     : VLSM (indexed_vlsm_free_projection_sig i)
     :=
       indexed_vlsm_constrained_projection i0 IM free_constraint i.
+          
 End free_projections.
+
+Section binary_composition.
+  Context
+    {message : Type}
+    {T1 T2 : VLSM_type message}
+    {S1 : LSM_sig T1}
+    {S2 : LSM_sig T2}
+    (M1 : VLSM S1)
+    (M2 : VLSM S2)
+    .
+
+  Inductive binary_index : Set := first : binary_index | second : binary_index.
+
+  Instance binary_index_dec : EqDec binary_index.
+    intros [|] [|].
+    - left; reflexivity.
+    - right; intro; discriminate.
+    - right; intro; discriminate.
+    - left; reflexivity.
+  Defined.
+
+  Definition binary_IT
+    (i : binary_index)
+    :=
+    match i with
+    | first => T1
+    | second => T2
+    end.
+  
+  Definition binary_IS (i : binary_index) : LSM_sig (binary_IT i)
+    :=
+    match i with
+    | first => S1
+    | second => S2
+    end.
+  
+  Definition binary_IM (i : binary_index) : VLSM (binary_IS i)
+    :=
+    match i with
+    | first => M1
+    | second => M2
+    end.
+
+  Definition binary_free_composition
+    : VLSM (indexed_sig first binary_IS)
+    := indexed_vlsm_free first binary_IM.
+
+  Definition binary_free_composition_fst
+    := indexed_vlsm_free_projection first binary_IM  first.
+
+  Definition binary_free_composition_snd
+    := indexed_vlsm_free_projection first binary_IM  second.
+
+End binary_composition.

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -1,4 +1,4 @@
-Require Import List Streams Nat.
+Require Import List Streams Nat Bool.
 Import ListNotations.
 Require Import Logic.FunctionalExtensionality.
 
@@ -1075,36 +1075,33 @@ Section binary_composition.
     (M2 : VLSM S2)
     .
 
-  Inductive binary_index : Set := first : binary_index | second : binary_index.
+  Definition binary_index : Set := bool.
 
-  Instance binary_index_dec : EqDec binary_index.
-    intros [|] [|].
-    - left; reflexivity.
-    - right; intro; discriminate.
-    - right; intro; discriminate.
-    - left; reflexivity.
-  Defined.
+  Definition first : binary_index := true.
+  Definition second : binary_index := false.
+
+  Program Instance binary_index_dec :  EqDec binary_index := bool_dec. 
 
   Definition binary_IT
     (i : binary_index)
     :=
     match i with
-    | first => T1
-    | second => T2
+    | true => T1
+    | false => T2
     end.
   
   Definition binary_IS (i : binary_index) : LSM_sig (binary_IT i)
     :=
     match i with
-    | first => S1
-    | second => S2
+    | true => S1
+    | false => S2
     end.
   
   Definition binary_IM (i : binary_index) : VLSM (binary_IS i)
     :=
     match i with
-    | first => M1
-    | second => M2
+    | true => M1
+    | false => M2
     end.
 
   Definition binary_free_composition


### PR DESCRIPTION
* Defined Byzantine traces using the "any VLSM composition" and using the "generating all messages VLSM" 
* Shown the two definitions equivalent, and equivalent with traces generated by the pre-loaded VLSM (where all messages are initial)