### PR TITLE
adjustment of coqdoc table of contents

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -4,7 +4,7 @@ JSFILES = resources/config.js resources/coqdocjs.js
 HTMLFILES = resources/header.html resources/footer.html
 COQDOCDIR = docs/coqdoc
 
-COQDOCHTMLFLAGS = --toc --toc-depth 2 --index indexpage --html \
+COQDOCHTMLFLAGS = --toc --toc-depth 2 --index indexpage --html -s \
   --interpolate --no-lib-name --parse-comments \
   --with-header resources/header.html --with-footer resources/footer.html
 

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,11 +1,12 @@
 -Q . CasperCBC
 
-Lib/ListExtras.v
-Lib/StreamExtras.v
-Lib/ListSetExtras.v
-Lib/Preamble.v
-Lib/RealsExtras.v
-Lib/SortedLists.v
+VLSM/Common.v
+VLSM/Composition.v
+VLSM/Decisions.v
+VLSM/ProjectionTraces.v
+VLSM/Validating.v
+VLSM/ByzantineTraces.v
+VLSM/FullNode.v
 CBC/Binary.v
 CBC/Common.v
 CBC/CTL.v
@@ -13,10 +14,9 @@ CBC/Definitions.v
 CBC/FullNode.v
 CBC/LightNode.v
 CBC/Protocol.v
-VLSM/ByzantineTraces.v
-VLSM/Common.v
-VLSM/Composition.v
-VLSM/Decisions.v
-VLSM/FullNode.v
-VLSM/ProjectionTraces.v
-VLSM/Validating.v
+Lib/StreamExtras.v
+Lib/RealsExtras.v
+Lib/ListSetExtras.v
+Lib/SortedLists.v
+Lib/ListExtras.v
+Lib/Preamble.v


### PR DESCRIPTION
This puts sections in `_CoqProject` in the right order and removes file names for the coqdoc table of contents.