### PR TITLE
Common Futures: definition and proof for decision consistency and finality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Makefile.coq.conf
 *_eq.v
 _build
 resources/index.html
+.lia.cache

--- a/Lib/ListExtras.v
+++ b/Lib/ListExtras.v
@@ -634,21 +634,18 @@ Proof.
       * inversion Hin1; inversion Hin2; subst; assumption.
       * destruct (nth_error_filter_index f l n2)
         ; inversion Hin1; inversion Hin2; subst.
-        apply le_0_n.
+        lia.
       * inversion Hle.
-      * apply le_S_n in Hle.
-        { destruct in1, in2.
-        - destruct (nth_error_filter_index f l n1); inversion Hin1.
-        - apply le_0_n.
+      * { destruct in1, in2; try lia.
         - destruct (nth_error_filter_index f l n2); inversion Hin2.
-        - specialize (IHl n1 n2 Hle).
+        - assert (Hle' : n1 <= n2) by lia.
+          specialize (IHl n1 n2 Hle').
           destruct (nth_error_filter_index f l n1) eqn:Hin1'; inversion Hin1;
           subst; clear Hin1.
           destruct (nth_error_filter_index f l n2) eqn:Hin2'; inversion Hin2
           ; subst; clear Hin2.
           specialize (IHl in1 eq_refl in2 eq_refl).
-          apply le_n_S.
-          assumption.
+          lia.
         }
     + specialize (IHl n1 n2 Hle).
       destruct (nth_error_filter_index f l n1) eqn:Hin1'; inversion Hin1
@@ -656,8 +653,7 @@ Proof.
       destruct (nth_error_filter_index f l n2) eqn:Hin2'; inversion Hin2
       ; subst; clear Hin2.
       specialize (IHl n eq_refl n0 eq_refl).
-      apply le_n_S.
-      assumption.
+      lia.
 Qed.
 
 Lemma nth_error_filter

--- a/Lib/ListExtras.v
+++ b/Lib/ListExtras.v
@@ -1,5 +1,6 @@
-Require Import Coq.Bool.Bool Coq.Arith.Lt Coq.Arith.Le Coq.Arith.Minus Coq.Arith.Plus.
+Require Import Coq.Bool.Bool.
 Require Import List.
+Require Import Lia.
 Import ListNotations.
 
 Require Import Coq.Logic.FinFun.
@@ -722,8 +723,8 @@ Proof.
   - inversion Hi.
   - inversion Hi.
   - simpl.
-    apply lt_S_n in Hi.
-    specialize (IHi s n Hi).
+    assert (Hi': i < n) by lia.
+    specialize (IHi s n Hi').
     rewrite IHi.
     reflexivity.
 Qed.
@@ -797,12 +798,13 @@ Lemma list_suffix_last
 Proof.
   generalize dependent l. induction i; intros [|a l] Hlt
   ; try reflexivity.
-  simpl in Hlt. apply lt_S_n in Hlt.
-  specialize (IHi l Hlt).
+  simpl in Hlt.
+  assert (Hlt': i < length l) by lia.
+  specialize (IHi l Hlt').
   rewrite unroll_last. simpl.
   rewrite IHi.
   destruct l.
-  - inversion Hlt.
+  - inversion Hlt; lia.
   - rewrite unroll_last. rewrite unroll_last. reflexivity.
 Qed.
 
@@ -849,7 +851,7 @@ Lemma list_segment_app
   : list_segment l n1 n2 ++ list_segment l n2 n3 = list_segment l n1 n3
   .
 Proof.
-  assert (Hle : n1 <= n3) by (apply le_trans with n2; assumption).
+  assert (Hle : n1 <= n3) by lia.
   specialize (list_prefix_segment_suffix l n1 n3 Hle); intro Hl1.
   specialize (list_prefix_segment_suffix l n2 n3 H23); intro Hl2.
   rewrite <- Hl2 in Hl1 at 4. clear Hl2.
@@ -885,8 +887,8 @@ Proof.
   specialize (list_suffix_length (list_prefix l (S n)) n).
   rewrite list_prefix_length; try assumption.
   intro Hlength.
-  rewrite <- minus_Sn_m in Hlength; try constructor.
-  rewrite <- minus_diag_reverse in Hlength.
+  assert (Hs: S n - n = 1) by lia.
+  rewrite Hs in Hlength.
   remember (list_suffix (list_prefix l (S n)) n) as x.
   clear -Hlength Hlast1.
   destruct x; inversion Hlength.

--- a/Lib/ListExtras.v
+++ b/Lib/ListExtras.v
@@ -1,4 +1,4 @@
-Require Import Coq.Bool.Bool Coq.Arith.Lt Coq.Arith.Plus.
+Require Import Coq.Bool.Bool Coq.Arith.Lt Coq.Arith.Le Coq.Arith.Minus Coq.Arith.Plus.
 Require Import List.
 Import ListNotations.
 
@@ -53,6 +53,36 @@ Proof.
   destruct l; try reflexivity.
   rewrite swap_head_last. rewrite unfold_last_hd. rewrite IHl.
   rewrite unfold_last_hd. reflexivity.
+Qed.
+
+Lemma last_app
+  {A}
+  (l1 l2 : list A)
+  (def : A)
+  : last (l1 ++ l2) def = last l2 (last l1 def)
+  .
+Proof.
+  generalize dependent def.
+  induction l1; try reflexivity; intro def.
+  remember last as lst; simpl; subst lst.
+  repeat rewrite unroll_last.
+  apply IHl1.
+Qed.
+
+Lemma last_map
+  {A B}
+  (f : A -> B)
+  (h : A)
+  (t : list A)
+  (def : B)
+  : last (map f (h :: t)) def = f (last t h)
+  .
+Proof.
+  generalize dependent def. generalize dependent h.
+  induction t; try reflexivity; intros.
+  rewrite map_cons.
+  repeat rewrite unroll_last.
+  apply IHt.
 Qed.
 
 Lemma incl_empty : forall A (l : list A),
@@ -536,6 +566,132 @@ Proof.
   reflexivity.
 Qed.
 
+Lemma nth_error_list_annotate
+  {A : Type}
+  (P : A -> Prop)
+  (l : list A)
+  (Hs : Forall P l)
+  (n : nat)
+  : exists (oa : option (sig P)),
+    nth_error (list_annotate P l Hs) n = oa
+    /\ option_map (@proj1_sig _ _) oa = nth_error l n
+  .
+Proof.
+  generalize dependent l.
+  induction n; intros [| a l] Hs.
+  - exists None. split; reflexivity.
+  - inversion Hs; subst. exists (Some (exist _ a (Forall_hd Hs))).
+    rewrite list_annotate_unroll.
+    split; reflexivity.
+  - exists None. split; reflexivity.
+  - rewrite list_annotate_unroll.
+    specialize (IHn l (Forall_tl Hs)).
+    destruct IHn as [oa [Hoa Hnth]].
+    exists oa.
+    split; assumption.
+Qed.
+
+Fixpoint nth_error_filter_index
+  {A}
+  (f : A -> bool)
+  (l : list A)
+  (n : nat)
+  :=
+  match l with 
+  | [] => None
+  | a :: l =>
+    match f a with
+    | false => option_map S (nth_error_filter_index f l n)
+    | true =>
+      match n with
+      | 0 => Some 0
+      | S n => option_map S (nth_error_filter_index f l n)
+      end
+    end
+  end.
+
+Lemma nth_error_filter_index_le
+  {A}
+  (f : A -> bool)
+  (l : list A)
+  (n1 n2 : nat)
+  (Hle : n1 <= n2)
+  (in1 in2 : nat)
+  (Hin1 : nth_error_filter_index f l n1 = Some in1)
+  (Hin2 : nth_error_filter_index f l n2 = Some in2)
+  : in1 <= in2.
+Proof.
+  generalize dependent in2. 
+  generalize dependent in1. 
+  generalize dependent n2. 
+  generalize dependent n1. 
+  induction l; intros.
+  - inversion Hin1.
+  - simpl in Hin1. simpl in Hin2.
+    destruct (f a) eqn:fa.
+    + destruct n1; destruct n2.
+      * inversion Hin1; inversion Hin2; subst; assumption.
+      * destruct (nth_error_filter_index f l n2)
+        ; inversion Hin1; inversion Hin2; subst.
+        apply le_0_n.
+      * inversion Hle.
+      * apply le_S_n in Hle.
+        { destruct in1, in2.
+        - destruct (nth_error_filter_index f l n1); inversion Hin1.
+        - apply le_0_n.
+        - destruct (nth_error_filter_index f l n2); inversion Hin2.
+        - specialize (IHl n1 n2 Hle).
+          destruct (nth_error_filter_index f l n1) eqn:Hin1'; inversion Hin1;
+          subst; clear Hin1.
+          destruct (nth_error_filter_index f l n2) eqn:Hin2'; inversion Hin2
+          ; subst; clear Hin2.
+          specialize (IHl in1 eq_refl in2 eq_refl).
+          apply le_n_S.
+          assumption.
+        }
+    + specialize (IHl n1 n2 Hle).
+      destruct (nth_error_filter_index f l n1) eqn:Hin1'; inversion Hin1
+      ; subst; clear Hin1.
+      destruct (nth_error_filter_index f l n2) eqn:Hin2'; inversion Hin2
+      ; subst; clear Hin2.
+      specialize (IHl n eq_refl n0 eq_refl).
+      apply le_n_S.
+      assumption.
+Qed.
+
+Lemma nth_error_filter
+  {A}
+  (f : A -> bool)
+  (l : list A)
+  (n : nat)
+  (a : A)
+  (Hnth : nth_error (filter f l) n = Some a)
+  : exists (nth : nat), 
+    nth_error_filter_index f l n = Some nth 
+    /\ nth_error l nth = Some a
+  .
+Proof.
+  generalize dependent a. generalize dependent n.
+  induction l.
+  - intros; simpl in Hnth. destruct n; inversion Hnth.
+  - intros. simpl in Hnth. simpl . destruct (f a).
+    + destruct n.
+      * inversion Hnth; subst. exists 0; split; reflexivity.
+      * simpl in Hnth.
+        specialize (IHl n a0 Hnth).
+        destruct IHl as [nth [Hnth' Ha0]].
+        exists (S nth).
+        split; try assumption.
+        rewrite Hnth'.
+        reflexivity.
+    + specialize (IHl n a0 Hnth).
+      destruct IHl as [nth [Hnth' Ha0]].
+      exists (S nth).
+      split; try assumption.
+      rewrite Hnth'.
+      reflexivity.
+Qed.
+
 Fixpoint filter_Forall
   {A : Type}
   (P : A -> Prop)
@@ -682,6 +838,60 @@ Proof.
   rewrite list_suffix_nth; try assumption.
   apply list_prefix_nth.
   assumption.
+Qed.
+
+Lemma list_segment_app
+  {A : Type}
+  (l : list A)
+  (n1 n2 n3 : nat)
+  (H12 : n1 <= n2)
+  (H23 : n2 <= n3)
+  : list_segment l n1 n2 ++ list_segment l n2 n3 = list_segment l n1 n3
+  .
+Proof.
+  assert (Hle : n1 <= n3) by (apply le_trans with n2; assumption).
+  specialize (list_prefix_segment_suffix l n1 n3 Hle); intro Hl1.
+  specialize (list_prefix_segment_suffix l n2 n3 H23); intro Hl2.
+  rewrite <- Hl2 in Hl1 at 4. clear Hl2.
+  repeat rewrite app_assoc in Hl1.
+  apply app_inv_tail in Hl1.
+  specialize (list_prefix_suffix (list_prefix l n2) n1); intro Hl2.
+  specialize (list_prefix_prefix l n1 n2 H12); intro Hl3.
+  rewrite Hl3 in Hl2.
+  rewrite <- Hl2 in Hl1.
+  rewrite <- app_assoc in Hl1.
+  apply app_inv_head in Hl1.
+  symmetry.
+  assumption.
+Qed.
+
+Lemma list_segment_singleton
+  {A : Type}
+  (l : list A)
+  (n : nat)
+  (a : A)
+  (Hnth : nth_error l n = Some a)
+  : list_segment l n (S n) = [a]
+  .
+Proof.
+  unfold list_segment.
+  assert (Hle : S n <= length l)
+    by (apply nth_error_length in Hnth; assumption).
+  assert (Hlt : n < length (list_prefix l (S n)))
+    by (rewrite list_prefix_length; try constructor; assumption).
+  specialize (list_suffix_last (list_prefix l (S n)) n Hlt a); intro Hlast1.
+  specialize (list_prefix_nth_last l n a Hnth a); intro Hlast2.
+  rewrite <- Hlast2 in Hlast1.
+  specialize (list_suffix_length (list_prefix l (S n)) n).
+  rewrite list_prefix_length; try assumption.
+  intro Hlength.
+  rewrite <- minus_Sn_m in Hlength; try constructor.
+  rewrite <- minus_diag_reverse in Hlength.
+  remember (list_suffix (list_prefix l (S n)) n) as x.
+  clear -Hlength Hlast1.
+  destruct x; inversion Hlength.
+  destruct x; inversion H0.
+  simpl in Hlast1; subst; reflexivity.
 Qed.
 
 Lemma nth_error_map

--- a/Lib/StreamExtras.v
+++ b/Lib/StreamExtras.v
@@ -1,9 +1,9 @@
-
-Require Import List Streams Coq.Arith.Le Coq.Arith.Lt Coq.Arith.Plus Coq.Arith.Minus Coq.Arith.Compare_dec.
+Require Import List Streams Coq.Arith.Compare_dec.
+Require Import Lia.
 Import ListNotations.
 
 From CasperCBC
-     Require Import Lib.ListExtras Preamble.
+Require Import Lib.ListExtras Preamble.
 
 Lemma recons
   {A : Type}
@@ -102,8 +102,8 @@ Proof.
   - inversion Hi.
   - inversion Hi.
   - simpl.
-    apply lt_S_n in Hi.
-    specialize (IHi s n Hi).
+    assert (Hi': i < n) by lia.
+    specialize (IHi s n Hi').
     rewrite IHi.
     reflexivity.
 Qed.
@@ -340,24 +340,16 @@ Proof.
     + rewrite list_suffix_length. rewrite stream_prefix_length. assumption.
   - rewrite stream_prefix_nth; try assumption.
     rewrite stream_suffix_nth.
-    assert (Hle : n1 <= n1 + k) by apply le_plus_l .
+    assert (Hle : n1 <= n1 + k) by lia.
     specialize (list_suffix_nth (stream_prefix l n2) n1 (n1 + k) Hle)
     ; intro Heq.
-    clear Hle.
-    rewrite minus_plus in Heq.
+    clear Hle.    
+    assert (Hs: n1 + k - n1 = k) by lia.
+    rewrite Hs in Heq.
     rewrite Heq.
     rewrite stream_prefix_nth.
-    + rewrite plus_comm. reflexivity.
-    + assert (Hle : n1 <= n2).
-      { destruct (le_dec n1 n2); try assumption.
-        rewrite not_le_minus_0  in l0; try assumption.
-        inversion l0.
-      }
-     apply (plus_lt_compat_l _ _ n1) in l0.
-     apply lt_le_trans with  (n1 + (n2 - n1)); try assumption.
-     apply le_plus_minus_r in Hle.
-     rewrite Hle.
-     constructor.
+    + rewrite Plus.plus_comm; reflexivity.
+    + lia.
 Qed.
 
 Lemma stream_prefix_segment
@@ -407,7 +399,7 @@ Lemma stream_segment_app
   : stream_segment l n1 n2 ++ stream_segment l n2 n3 = stream_segment l n1 n3
   .
 Proof.
-  assert (Hle : n1 <= n3) by (apply le_trans with n2; assumption).
+  assert (Hle : n1 <= n3) by lia.
   specialize (stream_prefix_segment_suffix l n1 n3 Hle); intro Hl1.
   specialize (stream_prefix_segment_suffix l n2 n3 H23); intro Hl2.
   rewrite <- Hl2 in Hl1 at 4. clear Hl2.
@@ -424,10 +416,7 @@ Proof.
     unfold stream_segment.
     repeat rewrite list_suffix_length.
     repeat rewrite stream_prefix_length.
-    apply le_plus_minus in Hle.
-    apply le_plus_minus in H23.
-    rewrite Hle in H23 at 1.
-    assumption.
+    lia.
 Qed.
 
 Definition monotone_nat_stream_prop
@@ -470,20 +459,19 @@ Proof.
   assert (Ha1 := Hs 0 (S n1) Hlt1).
   unfold Str_nth in Ha1.
   simpl in Ha1.
-  apply le_plus_minus_r in Ha1.
-  assert (Hlt2 : 0 < S n2) by (apply le_n_S; apply le_0_n).
-  assert (Ha2 := Hs 0 (S n2) Hlt2).
+  apply Minus.le_plus_minus_r in Ha1.
+  assert (Hlt2 : 0 < S n2) by lia.
+  pose proof (Hs 0 (S n2) Hlt2) as Ha2.
   unfold Str_nth in Ha2.
   simpl in Ha2.
-  apply le_plus_minus_r in Ha2.
-  apply plus_lt_reg_l with (S a).
+  apply Minus.le_plus_minus_r in Ha2.
+  apply Plus.plus_lt_reg_l with (S a).
   unfold Str_nth.
   rewrite Ha1.
   rewrite Ha2.
   specialize (Hs (S n1) (S n2)).
   apply Hs.
-  apply le_n_S.
-  assumption.
+  lia.
 Qed.
 
 Definition monotone_nat_stream_suffix
@@ -538,24 +526,22 @@ Proof.
     unfold ks in *; clear ks.
     destruct kss as [(k, ks) Hseq]; simpl in *.
     destruct k0.
-    + elim (succ_plus_discr k n).
+    + elim (Plus.succ_plus_discr k n).
       assumption.
     + exists k0. unfold nat_sequence_suffix.
       rewrite Str_nth_map .
       simpl.
       unfold Str_nth in Heq; simpl in Heq.
-      assert (Hlt0 : 0 < (S k0)) by (apply le_n_S; apply le_0_n).
+      assert (Hlt0 : 0 < (S k0)) by lia.
       clear kss'.
       specialize (Hseq 0 (S k0) Hlt0).
       unfold Str_nth in Hseq; simpl in Hseq.
-      apply le_plus_minus_r in Hseq.
-      apply plus_reg_l  with (S k).
+      apply Minus.le_plus_minus_r in Hseq.
+      apply Plus.plus_reg_l  with (S k).
       unfold Str_nth.
       rewrite Hseq.
       rewrite Heq.
-      simpl.
-      f_equal.
-      apply plus_comm.
+      lia.
   - apply proj2 in Hfs. apply Hfs. clear Hfs.
     destruct H as [k Heq].
     exists (S k).
@@ -563,15 +549,15 @@ Proof.
     rewrite Str_nth_map in Heq.
     unfold ks in *; clear ks.
     destruct kss as [(k0, ks) Hseq]; simpl in *.
-    assert (Hlt : 0 < (S k)) by (apply le_n_S; apply le_0_n).
+    assert (Hlt : 0 < (S k)) by lia.
     clear kss'.
     specialize (Hseq 0 (S k) Hlt).
     unfold Str_nth in *; simpl in *.
-    apply le_plus_minus_r in Hseq.
+    apply Minus.le_plus_minus_r in Hseq.
     rewrite <- Hseq. rewrite Heq.
     simpl.
     f_equal.
-    apply plus_comm.
+    lia.
 Qed.
 
 Definition stream_subsequence
@@ -619,10 +605,10 @@ Proof.
   unfold n in *; clear n.
   simpl in ss'.
   clear Heq kss'.
-  assert (Hlt : 0 < S n') by  (apply le_n_S; apply le_0_n).
+  assert (Hlt : 0 < S n') by lia.
   specialize (Hks 0 (S n') Hlt).
-  apply le_plus_minus_r in Hks.
-  rewrite plus_comm. simpl.
+  apply Minus.le_plus_minus_r in Hks.
+  rewrite Plus.plus_comm. simpl.
   unfold Str_nth in Hks; simpl in Hks.
   unfold Str_nth at 4; simpl.
   rewrite Hks.
@@ -779,7 +765,7 @@ Proof.
     apply Hinj.
     rewrite app_length.
     repeat (rewrite stream_prefix_length).
-    rewrite plus_comm.
+    rewrite Plus.plus_comm.
     reflexivity.
 Qed.
 
@@ -831,12 +817,11 @@ Proof.
   specialize (Hfs p).
   destruct Hfs as [i Heqki].
   specialize (Hseq 0 i).
-  specialize (lt_irrefl k0); intro H; elim H.
+  specialize (Lt.lt_irrefl k0); intro H; elim H.
   destruct i; subst; try assumption.
-  apply lt_trans with k; try assumption.
+  apply Lt.lt_trans with k; try assumption.
   apply Hseq.
-  apply le_n_S.
-  apply le_0_n.
+  lia.
 Qed.
 
 
@@ -895,13 +880,13 @@ Proof.
     clear Hfs kn ss_to_kn H0 Hfs' Hsss Hpref.
     specialize (Hseq 0 (S n) Hle).
     unfold Str_nth in Hseq. simpl in Hseq.
-    apply plus_reg_l  with k.
+    apply Plus.plus_reg_l  with k.
     simpl.
-    rewrite <- plus_Snm_nSm .
-    repeat rewrite le_plus_minus_r; trivial.
+    rewrite <- Plus.plus_Snm_nSm .
+    repeat rewrite Minus.le_plus_minus_r; trivial.
     unfold lt in Hseq.
-    apply le_trans with (S k); try assumption.
-    constructor. constructor.
+    apply Le.le_trans with (S k); [|assumption].
+    lia.
   }
   rewrite Heq' in Heq.
   rewrite <- Heq.
@@ -919,8 +904,7 @@ Proof.
     assert (Hlt : 0 < S n) by  (apply le_n_S; apply le_0_n).
     apply Hseq in Hlt.
     unfold Str_nth in *; simpl in *.
-    apply le_trans with ( hd (Str_nth_tl n ks)); try assumption.
-    constructor. constructor.
+    lia.
 Qed.
 
 Lemma stream_prefix_nth_last
@@ -961,8 +945,8 @@ Proof.
   specialize (list_suffix_length (stream_prefix l (S n)) n).
   rewrite stream_prefix_length; try assumption.
   intro Hlength.
-  rewrite <- minus_Sn_m in Hlength; try constructor.
-  rewrite <- minus_diag_reverse in Hlength.
+  rewrite <- Minus.minus_Sn_m in Hlength by lia.
+  rewrite <- Minus.minus_diag_reverse in Hlength.
   remember (list_suffix (stream_prefix l (S n)) n) as x.
   rewrite <- Heqa in Hlast1.
   clear -Hlength Hlast1.

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -1,3 +1,4 @@
+Require Import Lia.
 Require Import List Streams ProofIrrelevance Coq.Arith.Plus Coq.Arith.Minus.
 Import ListNotations.
 
@@ -1465,7 +1466,8 @@ This relation is often used in stating safety and liveness properties.*)
         intro Hsuf.
         apply finite_ptrace_first_pstate in Hsuf.
         assumption.
-      - specialize (infinite_protocol_trace_from_segment s0 l Htr n n (le_n n))
+      - assert (Hle : n <= n) by lia.
+        specialize (infinite_protocol_trace_from_segment s0 l Htr n n Hle)
         ; simpl; intros Hseg.
         inversion Hnth.
         apply finite_ptrace_first_pstate in Hseg.
@@ -1533,7 +1535,7 @@ This relation is often used in stating safety and liveness properties.*)
         + reflexivity.
       -  exists (trace_segment tr n1 (S m)).
         split.
-        + apply ptrace_segment; try assumption. constructor. assumption.
+        + apply ptrace_segment; try assumption. lia.
         + { destruct tr as [s tr | s tr]; simpl.
           - unfold list_segment.
             rewrite list_suffix_map. rewrite list_prefix_map.
@@ -1543,7 +1545,7 @@ This relation is often used in stating safety and liveness properties.*)
             + apply nth_error_length in Hs2.
               specialize (list_prefix_length (List.map destination tr) (S m) Hs2); intro Hpref_len.
               rewrite Hpref_len.
-              apply le_n_S. assumption.
+              lia.
           - unfold stream_segment.
             rewrite list_suffix_map. rewrite stream_prefix_map.
             simpl in Hs2.
@@ -1554,7 +1556,7 @@ This relation is often used in stating safety and liveness properties.*)
               reflexivity.
             + specialize (stream_prefix_length (Streams.map destination tr) (S m)); intro Hpref_len.
               rewrite Hpref_len.
-              apply le_n_S. assumption.
+              lia.
           }
     Qed.
     (* end hide *)

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -543,7 +543,7 @@ decompose the above properties in proofs.
       .
     Proof.
       inversion Htr; subst; try assumption.
-      - destruct H0 as [[Hs _] _]. assumption.
+      destruct H0 as [[Hs _] _]. assumption.
     Qed.
 
     Lemma finite_ptrace_tail
@@ -808,7 +808,6 @@ definitions, mostly reducing them to properties about their finite segments.
       assumption.
     Qed.
 
-
     Lemma infinite_protocol_trace_from_segment
       (s : state)
       (ls : Stream transition_item)
@@ -1063,6 +1062,24 @@ It inherits some previously introduced definitions, culminating with the
         apply Hextend.
         Qed.
 
+    Lemma trace_is_protocol
+      (is : initial_state)
+      (tr : list transition_item)
+      (Htr : finite_protocol_trace_from (proj1_sig is) tr)
+      : protocol_state_prop (last (List.map destination tr) (proj1_sig is))
+      .
+    Proof.
+      specialize (trace_is_run is tr Htr); simpl; intro Hrun.
+      destruct Hrun as [run [Hrun [Hstart Htrans]]].
+      specialize (run_is_protocol (exist _ run Hrun)); simpl; intro Hps.
+      specialize (vlsm_run_last_state (exist _ run Hrun)); simpl; intros Hlast'.
+      rewrite Htrans in Hlast'. rewrite Hstart in Hlast'. 
+      destruct (final run) as (s', om). simpl in Hlast'.
+      exists om.
+      subst.
+      assumption.
+    Qed.
+
         (* end hide *)
 
 (** Having defined [protocol_trace]s, we now connect them to protocol states
@@ -1119,42 +1136,66 @@ with <<first>> and ends in <<second>>.
 This relation is often used in stating safety and liveness properties.*)
 
     Definition in_futures
-      (pfirst psecond : protocol_state)
-      (first := proj1_sig pfirst)
-      (second := proj1_sig psecond)
+      (first second : state)
       : Prop :=
       exists (tr : list transition_item),
         finite_protocol_trace_from first tr /\
         last (List.map destination tr) first = second.
+    
+    Lemma in_futures_protocol_fst
+      (first second : state)
+      (Hfuture: in_futures first second)
+      : protocol_state_prop first.
+    Proof.
+      destruct Hfuture as [tr [Htr Hlast]].
+      apply finite_ptrace_first_pstate in Htr.
+      assumption.
+    Qed.
 
     (* begin hide *)
 
-    Lemma in_futures_reflexive
-      (pfirst: protocol_state)
-      : in_futures pfirst pfirst.
+    Lemma in_futures_refl
+      (first: state)
+      (Hps : protocol_state_prop first)
+      : in_futures first first.
 
     Proof.
-    unfold in_futures.
     exists [].
     split.
     - apply finite_ptrace_empty.
-      destruct pfirst. assumption.
-     - simpl. auto.
+      assumption.
+    - reflexivity.
+    Qed.
+
+    Lemma in_futures_trans
+      (first second third : state)
+      (H12: in_futures first second)
+      (H23 : in_futures second third)
+      : in_futures first third
+      .
+    Proof.
+      destruct H12 as [tr12 [Htr12 Hsnd]].
+      destruct H23 as [tr23 [Htr23 Hthird]].
+      subst second.
+      specialize (finite_protocol_trace_from_app_iff first tr12 tr23); simpl; intros [Happ _].
+      specialize (Happ (conj Htr12 Htr23)).
+      exists (tr12 ++ tr23).
+      split; try assumption.
+      rewrite map_app.
+      rewrite last_app.
+      assumption.
     Qed.
 
     Lemma in_futures_witness
-      (pfirst psecond : protocol_state)
-      (first := proj1_sig pfirst)
-      (second := proj1_sig psecond)
-      (Hfutures : in_futures pfirst psecond)
+      (first second : state)
+      (Hfutures : in_futures first second)
       : exists (tr : protocol_trace) (n1 n2 : nat),
         n1 <= n2
         /\ trace_nth (proj1_sig tr) n1 = Some first
         /\ trace_nth (proj1_sig tr) n2 = Some second.
     Proof.
-      unfold first in *; clear first. unfold second in *; clear second.
-      destruct pfirst as [first [_mfirst Hfirst]].
-      destruct psecond as [second [_msecond Hsecond]].
+      specialize (in_futures_protocol_fst first second Hfutures); intro Hps.
+      destruct Hps as [_mfirst Hfirst].
       simpl.
       unfold in_futures in Hfutures. simpl in Hfutures.
       destruct Hfutures as [suffix_tr [Hsuffix_tr Hsnd]].
@@ -1249,55 +1290,6 @@ This relation is often used in stating safety and liveness properties.*)
         apply (infinite_protocol_trace_from_segment s tr Htr n1 n2 Hle).
     Qed.
 
-    Lemma in_futures_witness_reverse
-      (pfirst psecond : protocol_state)
-      (first := proj1_sig pfirst)
-      (second := proj1_sig psecond)
-      (H : exists (tr : protocol_trace) (n1 n2 : nat),
-        n1 <= n2
-        /\ trace_nth (proj1_sig tr) n1 = Some first
-        /\ trace_nth (proj1_sig tr) n2 = Some second
-      )
-      : in_futures pfirst psecond.
-    Proof.
-      destruct H as [[tr Htr] [n1 [n2 [Hle [Hs1 Hs2]]]]].
-      unfold in_futures. unfold first in *. clear first.
-      unfold second in *. clear second.
-      destruct pfirst as [first Hfirst].
-      destruct psecond as [second Hsecond].
-      simpl in *.
-      inversion Hle; subst; clear Hle.
-      - rewrite Hs1 in Hs2. inversion Hs2; subst; clear Hs2.
-        exists []. split.
-        + constructor. assumption.
-        + reflexivity.
-      -  exists (trace_segment tr n1 (S m)).
-        split.
-        + apply ptrace_segment; try assumption. constructor. assumption.
-        + { destruct tr as [s tr | s tr]; simpl.
-          - unfold list_segment.
-            rewrite list_suffix_map. rewrite list_prefix_map.
-            simpl in Hs2.
-            rewrite list_suffix_last.
-            + symmetry. apply list_prefix_nth_last. assumption.
-            + apply nth_error_length in Hs2.
-              specialize (list_prefix_length (List.map destination tr) (S m) Hs2); intro Hpref_len.
-              rewrite Hpref_len.
-              apply le_n_S. assumption.
-          - unfold stream_segment.
-            rewrite list_suffix_map. rewrite stream_prefix_map.
-            simpl in Hs2.
-            rewrite list_suffix_last.
-            + symmetry. rewrite stream_prefix_nth_last.
-              unfold Str_nth in Hs2. simpl in Hs2.
-              inversion Hs2; subst.
-              reflexivity.
-            + specialize (stream_prefix_length (Streams.map destination tr) (S m)); intro Hpref_len.
-              rewrite Hpref_len.
-              apply le_n_S. assumption.
-          }
-    Qed.
-
     Inductive Trace_messages : Type :=
     | Finite_messages : list (option message) -> Trace_messages
     | Infinite_messages : Stream (option message) -> Trace_messages.
@@ -1322,39 +1314,16 @@ This relation is often used in stating safety and liveness properties.*)
         | Infinite s st => exists suffix, st = stream_app prefix (Cons last suffix)
         end.
 
-    (* end hide *)
-
-(**
-Stating livness properties will require quantifying over complete
-executions of the protocol. To make this possible, we will now define
-_complete_ [protocol_trace]s.
-
-A [protocol_trace] is _terminating_ if there's no other [protocol_trace]
-that contains it as a prefix.
-*)
-
-    Definition terminating_trace_prop (tr : Trace) : Prop
-       :=
-         match tr with
-         | Finite s ls =>
-             (exists (tr : protocol_trace)
-             (last : transition_item),
-             trace_prefix (proj1_sig tr) last ls) -> False
-         | Infinite s ls => False
-         end.
-
-(** A [protocol_trace] is _complete_, if it is either _terminating_ or infinite.
-*)
-
-    Definition complete_trace_prop (tr : Trace) : Prop
-       := protocol_trace_prop tr
-          /\
-          match tr with
-          | Finite _ _ => terminating_trace_prop tr
-          | Infinite _ _ => True
-          end.
-
-    (* begin hide *)
+    Definition trace_prefix_fn
+      (tr : Trace)
+      (n : nat)
+      : Trace
+      := 
+      match tr with
+      | Finite s ls => Finite s (list_prefix ls n)
+      | Infinite s st => Finite s (stream_prefix st n)
+      end.
+    
     Lemma trace_prefix_protocol
           (tr : protocol_trace)
           (last : transition_item)
@@ -1434,6 +1403,193 @@ that contains it as a prefix.
           simpl.
           rewrite map_app. simpl. rewrite last_is_last. tauto.
     Qed.
+
+    Lemma trace_prefix_fn_protocol
+          (tr : Trace)
+          (Htr : protocol_trace_prop tr)
+          (n : nat)
+      : protocol_trace_prop (trace_prefix_fn tr n)
+      .
+    Proof.
+      specialize (trace_prefix_protocol (exist _ tr Htr)); simpl; intro Hpref.
+      remember (trace_prefix_fn tr n) as pref_tr.
+      destruct pref_tr as [s l | s l].
+      - destruct l as [| item l].
+        + destruct tr as [s' l' | s' l']
+          ; destruct Htr as [Htr Hinit]
+          ; inversion Heqpref_tr
+          ; subst
+          ; split; try assumption
+          ; constructor
+          ; replace s' with (proj1_sig (exist _ s' Hinit))
+          ; try reflexivity
+          ; exists None
+          ; apply protocol_initial_state
+          .
+        + assert (Hnnil : item ::l <> [])
+            by (intro Hnil; inversion Hnil).
+          specialize (exists_last Hnnil); intros [prefix [last Heq]].
+          rewrite Heq in *; clear Hnnil Heq l item.
+          replace s with (trace_first (proj1_sig (exist _ tr Htr)))
+          ; try (destruct tr; inversion Heqpref_tr; subst; reflexivity).
+          apply trace_prefix_protocol.
+          destruct tr as [s' l' | s' l']
+          ; inversion Heqpref_tr
+          ; subst
+          ; clear Heqpref_tr
+          ; simpl.
+          * specialize (list_prefix_suffix l' n); intro Hl'.
+            rewrite <- Hl'. rewrite <- H1.
+            exists (list_suffix l' n).
+            rewrite <- app_assoc.
+            reflexivity.
+          * specialize (stream_prefix_suffix l' n); intro Hl'.
+            rewrite <- Hl'. rewrite <- H1.
+            exists (stream_suffix l' n).
+            rewrite <- stream_app_assoc.
+            reflexivity.
+      - destruct tr as [s' l' | s' l']; inversion Heqpref_tr.
+    Qed.
+
+    Lemma protocol_trace_nth
+      (tr : Trace)
+      (Htr : protocol_trace_prop tr)
+      (n : nat)
+      (s : state)
+      (Hnth : trace_nth tr n = Some s)
+      : protocol_state_prop s
+      .
+    Proof.
+      destruct tr as [s0 l | s0 l]; destruct Htr as [Htr Hinit].
+      - specialize (finite_protocol_trace_from_suffix s0 l Htr n s Hnth).
+        intro Hsuf.
+        apply finite_ptrace_first_pstate in Hsuf.
+        assumption.
+      - specialize (infinite_protocol_trace_from_segment s0 l Htr n n (le_n n))
+        ; simpl; intros Hseg.
+        inversion Hnth.
+        apply finite_ptrace_first_pstate in Hseg.
+        assumption.
+    Qed.
+(* alternate proof without assuming protocol_transition implies protocol_state
+      destruct n.
+      - exists None.
+        destruct tr as [s0 l | s0 l]
+        ; inversion Hnth; try (unfold Str_nth in H0; simpl in H0); subst; clear Hnth
+        ; destruct Htr as [_ Hinit]
+        ; replace s with (proj1_sig (exist _ s Hinit)); try reflexivity
+        ;  apply protocol_initial_state.
+      - specialize (trace_prefix_fn_protocol tr Htr (S n)); intro Hpref_tr.
+        remember (trace_prefix_fn tr (S n)) as pref_tr.
+        destruct pref_tr as [s0 l | s0 l]
+        ; try (destruct tr as [s' l' | s' l']; inversion Heqpref_tr)
+        ; subst; clear Heqpref_tr
+        ; destruct Hpref_tr as [Hpref_tr Hinit]
+        ; specialize (trace_is_protocol (exist _ s' Hinit)); intro Hps
+        ; specialize (Hps (list_prefix l' (S n))) || specialize (Hps (stream_prefix l' (S n)))
+        ; specialize (Hps Hpref_tr)
+        ; rewrite list_prefix_map in Hps || rewrite stream_prefix_map in Hps
+        ; destruct Hps as [om Hps]
+        ; exists om
+        .
+        + replace s with (last (list_prefix (List.map destination l') (S n)) s')
+          ; try assumption.
+          symmetry.
+          apply list_prefix_nth_last.
+          assumption.
+        + replace s with (last (stream_prefix (Streams.map destination l') (S n)) s')
+          ; try assumption.
+          rewrite stream_prefix_nth_last.
+          inversion Hnth.
+          reflexivity.
+*)
+
+    Lemma in_futures_protocol_snd
+      (first second : state)
+      (Hfutures: in_futures first second)
+      : protocol_state_prop second.
+    Proof.
+      specialize (in_futures_witness first second Hfutures)
+      ; intros [tr [n1 [n2 [Hle [Hn1 Hn2]]]]].
+      destruct tr as [tr Htr]; simpl in Hn2.
+      apply protocol_trace_nth with tr n2; assumption.
+    Qed.
+
+    Lemma in_futures_witness_reverse
+      (first second : state)
+      (tr : protocol_trace)
+      (n1 n2 : nat)
+      (Hle : n1 <= n2)
+      (Hs1 : trace_nth (proj1_sig tr) n1 = Some first)
+      (Hs2 : trace_nth (proj1_sig tr) n2 = Some second)
+      : in_futures first second.
+    Proof.
+      destruct tr as [tr Htr].
+      simpl in *.
+      inversion Hle; subst; clear Hle.
+      - rewrite Hs1 in Hs2. inversion Hs2; subst; clear Hs2.
+        exists []. split.
+        + constructor. apply protocol_trace_nth with tr n2; assumption.
+        + reflexivity.
+      -  exists (trace_segment tr n1 (S m)).
+        split.
+        + apply ptrace_segment; try assumption. constructor. assumption.
+        + { destruct tr as [s tr | s tr]; simpl.
+          - unfold list_segment.
+            rewrite list_suffix_map. rewrite list_prefix_map.
+            simpl in Hs2.
+            rewrite list_suffix_last.
+            + symmetry. apply list_prefix_nth_last. assumption.
+            + apply nth_error_length in Hs2.
+              specialize (list_prefix_length (List.map destination tr) (S m) Hs2); intro Hpref_len.
+              rewrite Hpref_len.
+              apply le_n_S. assumption.
+          - unfold stream_segment.
+            rewrite list_suffix_map. rewrite stream_prefix_map.
+            simpl in Hs2.
+            rewrite list_suffix_last.
+            + symmetry. rewrite stream_prefix_nth_last.
+              unfold Str_nth in Hs2. simpl in Hs2.
+              inversion Hs2; subst.
+              reflexivity.
+            + specialize (stream_prefix_length (Streams.map destination tr) (S m)); intro Hpref_len.
+              rewrite Hpref_len.
+              apply le_n_S. assumption.
+          }
+    Qed.
+    (* end hide *)
+
+(**
+Stating livness properties will require quantifying over complete
+executions of the protocol. To make this possible, we will now define
+_complete_ [protocol_trace]s.
+
+A [protocol_trace] is _terminating_ if there's no other [protocol_trace]
+that contains it as a prefix.
+*)
+
+    Definition terminating_trace_prop (tr : Trace) : Prop
+       :=
+         match tr with
+         | Finite s ls =>
+             (exists (tr : protocol_trace)
+             (last : transition_item),
+             trace_prefix (proj1_sig tr) last ls) -> False
+         | Infinite s ls => False
+         end.
+
+(** A [protocol_trace] is _complete_, if it is either _terminating_ or infinite.
+*)
+
+    Definition complete_trace_prop (tr : Trace) : Prop
+       := protocol_trace_prop tr
+          /\
+          match tr with
+          | Finite _ _ => terminating_trace_prop tr
+          | Infinite _ _ => True
+          end.
+
+    (* begin hide *)
 
     (* Implicitly, the state itself must be in the trace, and minimally the last element of the trace *)
     (* Also implicitly, the trace leading up to the state is finite *)

--- a/VLSM/CommonFutures.v
+++ b/VLSM/CommonFutures.v
@@ -1,0 +1,107 @@
+From CasperCBC
+  Require Import
+    Lib.Preamble
+    VLSM.Common VLSM.Composition VLSM.Decisions VLSM.ProjectionTraces
+    CBC.Common
+    .
+
+(** * Common Futures and Decision Consistency *)
+
+(**
+In this section we provide a definition for the [HasCommonFuturesEstimates]
+property and then we show that a VLSM equiped with this property 
+has [final_and_consistent] decisions.
+*)
+
+Section CommonFutures.
+
+Context
+  {message : Type}
+  {index : Type}
+  {IndEqDec : EqDec index}
+  (i0 : index)
+  {IT : index -> VLSM_type message}
+  {IS : forall i : index, VLSM_sign (IT i)}
+  (IM : forall n : index, VLSM (IS n))
+  (T := composite_type IT)
+  (S := composite_sig i0 IS)
+  (constraint : @label _ T -> @state _ T * option message -> Prop)
+  (X := composite_vlsm i0 IM constraint)
+  {CV : consensus_values}
+  (IE : forall i : index, Estimator (@state _ (IT i)) C)
+  (ID : forall i : index, decision (IT i))
+  (DE : forall i : index, decision_estimator_property i0 IM constraint ID IE i)
+  .
+
+(**
+Let us fix an indexed set of VLSMs <<IM>> and their composition <<X>> using <<constraint>>.
+For each component of index i, let <<IE i>> be an [Estimator] for Xi and let 
+<<ID i>> be a [decision] function for Xi, linked together by the
+[decision_estimator_property].
+
+*)
+
+(** ** Common futures estimates definition *)
+
+(**
+We say that the composition <<X>> [HasCommonFutureEstimates] if there
+exists a function [union] taking composite states to composit states
+such that for each composite state <<s>>, its [union_is_reachable] from <<s>>,
+and the [union_has_consistent_estimators]; i.e.,
+all components yields the same estimates.
+*)
+
+Class HasCommonFutureEstimates := 
+  { union : @state _ T -> @state _ T
+  ; union_is_reachable
+    : forall
+      (s : @state _ T)
+      (Hps : protocol_state_prop X s)
+      , in_futures X s (union s)
+  ; union_has_consistent_estimators
+    : forall
+      (s : @state _ T)
+      (Hps : protocol_state_prop X s)
+      (i j : index)
+      (c : C),
+      estimator (union s i) c <-> estimator (union s j) c
+  }.
+
+(** ** Final and consistent decisions
+
+If a [VLSM] composition <<X>> [HasCommonFuturesEstimates] and its component
+decisions are linked with the corresponding estimators through the
+[decision_estimator_property], then <<X>> has [final_and_consistent]
+decisions.
+*)
+
+
+Lemma consistent_estimator_decisions
+  (HCFE : HasCommonFutureEstimates)
+  : final_and_consistent i0 IM constraint ID.
+Proof.
+  unfold final_and_consistent; intros.
+  specialize (in_futures_protocol_snd X s1 s2 Hfuture); intros Hps2.
+  specialize (union_is_reachable s2 Hps2); intro HcmnFuture.
+  specialize (union_has_consistent_estimators s2 Hps2 j k)
+  ; intros HconsEst.
+  specialize (in_futures_trans X s1 s2 (union s2) Hfuture HcmnFuture)
+  ; intro HcmnFuture1.
+  specialize (in_futures_projection i0 IM constraint j s1 (union s2) HcmnFuture1)
+  ; intros HFuture1.
+  assert (Dej := DE j).
+  specialize (Dej (s1 j) c1 HDecided1 (union s2 j) HFuture1).
+  specialize (in_futures_projection i0 IM constraint k s2 (union s2) HcmnFuture)
+  ; intros HFuture2.
+  assert (Dek := DE k).
+  specialize (Dek (s2 k) c2 HDecided2 (union s2 k) HFuture2).
+  specialize (estimator_total (union s2 j)); intros [c Hc].
+  specialize (HconsEst c).
+  specialize (Dej c Hc).
+  apply HconsEst in Hc.
+  specialize (Dek c Hc).
+  subst.
+  reflexivity.
+Qed.
+
+End CommonFutures.

--- a/VLSM/Decisions.v
+++ b/VLSM/Decisions.v
@@ -1,6 +1,7 @@
 Require Import Coq.Logic.FinFun.
 Require Import Bool List Streams Logic.Epsilon.
-Require Import Coq.Arith.Compare_dec Coq.Arith.Le.
+Require Import Coq.Arith.Compare_dec.
+Require Import Lia.
 Import List Notations.
 From CasperCBC
   Require Import
@@ -152,8 +153,7 @@ Section CommuteIndexed.
       ; intros Hfutures.
       specialize (Hconsistent s1 s2 Hfutures j k Hneq c1 c2 HD1 HD2).
       assumption.
-    - assert (Hle : n2 <= n1)
-        by (apply le_trans with (S n2); try assumption; repeat constructor).
+    - assert (Hle : n2 <= n1) by lia.
       clear l.
       specialize (in_futures_witness_reverse X s2 s1 tr n2 n1 Hle Hs2 Hs1)
       ; intros Hfutures.

--- a/VLSM/Decisions.v
+++ b/VLSM/Decisions.v
@@ -1,8 +1,12 @@
 Require Import Coq.Logic.FinFun.
 Require Import Bool List Streams Logic.Epsilon.
+Require Import Coq.Arith.Compare_dec Coq.Arith.Le.
 Import List Notations.
 From CasperCBC
-Require Import Lib.Preamble Lib.ListExtras Lib.ListSetExtras Lib.RealsExtras CBC.Protocol CBC.Common CBC.Definitions VLSM.Common VLSM.Composition.
+  Require Import
+    Lib.Preamble Lib.ListExtras Lib.ListSetExtras Lib.RealsExtras
+    CBC.Protocol CBC.Common CBC.Definitions
+    VLSM.Common VLSM.Composition VLSM.ProjectionTraces.
 
 (* 3.1 Decisions on consensus values *)
 
@@ -25,13 +29,6 @@ Section CommuteSingleton.
     (V : VLSM S).
 
   (* 3.2.1 Decision finality *)
-  (* Program Definition prot_state0 {VLSM} : protocol_state :=
-    exist protocol_state_prop (proj1_sig s0) _.
-  Next Obligation.
-    red.
-    exists None.
-    constructor.
-  Defined. *)
 
   (* Definition of finality per document. *)
   Definition final_original : decision T -> Prop :=
@@ -45,10 +42,10 @@ Section CommuteSingleton.
 
   (* Definition of finality using in_futures, which plays better with the estimator property *)
   Definition final: decision T -> Prop :=
-  fun (D : decision T) => forall (s1 s2 : protocol_state V) (c1 c2 : C),
+  fun (D : decision T) => forall (s1 s2 : @state _ T) (c1 c2 : C),
         in_futures V s1 s2 ->
-        (D (proj1_sig s1) = (Some c1)) ->
-        (D (proj1_sig s2) = (Some c2)) ->
+        (D s1 = (Some c1)) ->
+        (D s2 = (Some c2)) ->
         c1 = c2.
 
   (* 3.3.1 Initial protocol state bivalence *)
@@ -94,7 +91,7 @@ Section CommuteIndexed.
 
   Context
     {CV : consensus_values}
-    {index : Set}
+    {index : Type}
     {Heqd : EqDec index}
     {message : Type}
     {IT : index -> VLSM_type message}
@@ -105,9 +102,13 @@ Section CommuteIndexed.
     (X := composite_vlsm Hi IM constraint)
     (ID : forall i : index, decision (IT i)).
 
-  (* 3.2.2 Decision consistency *)
+  (* ** Decision consistency
+  
+  First, let us introduce a definition of consistency which
+  looks at states as belonging to a trace.
+  *)
 
-  Definition consistent :=
+  Definition consistent_original :=
       forall (tr : protocol_trace X),
       forall (n1 n2 : nat),
       forall (j k : index),
@@ -120,31 +121,94 @@ Section CommuteIndexed.
       (ID k) (s2 k) = (Some c2) ->
       c1 = c2.
 
+  (**
+
+  Now let us give an alternative definition based on [in_futures]:
+  *)
+  
+  Definition consistent :=
+      forall
+        (s1 s2 : @state _ (composite_type IT))
+        (Hfuture : in_futures X s1 s2)
+        (j k : index)
+        (Hneq : j <> k)
+        (c1 c2 : C)
+        (HDecided1 : (ID j) (s1 j) = Some c1)
+        (HDecided2 : (ID k) (s2 k) = Some c2)
+        , c1 = c2.
+
+
+  (**
+  Next two results show that the two definitions above are equivalent.
+  *)
+
+  Lemma consistent_to_original
+    (Hconsistent : consistent)
+    : consistent_original.
+  Proof.
+    intros tr n1 n2 j k s1 s2 c1 c2 Hneq Hs1 Hs2 HD1 HD2.
+    destruct (le_lt_dec n1 n2).
+    - specialize (in_futures_witness_reverse X s1 s2 tr n1 n2 l Hs1 Hs2)
+      ; intros Hfutures.
+      specialize (Hconsistent s1 s2 Hfutures j k Hneq c1 c2 HD1 HD2).
+      assumption.
+    - assert (Hle : n2 <= n1)
+        by (apply le_trans with (S n2); try assumption; repeat constructor).
+      clear l.
+      specialize (in_futures_witness_reverse X s2 s1 tr n2 n1 Hle Hs2 Hs1)
+      ; intros Hfutures.
+      assert (Hneq' : k <> j)
+        by (intro Heq; elim Hneq; symmetry; assumption).
+      specialize (Hconsistent s2 s1 Hfutures k j Hneq' c2 c1 HD2 HD1).
+      symmetry.
+      assumption.
+    Qed.
+
+  Lemma original_to_consistent
+    (Horiginal : consistent_original)
+    : consistent.
+  Proof.
+    unfold consistent; intros.
+    specialize (in_futures_witness X s1 s2 Hfuture)
+    ; intros [tr [n1 [n2 [Hle [Hs1 Hs2]]]]].
+    specialize (Horiginal tr n1 n2 j k s1 s2 c1 c2 Hneq Hs1 Hs2 HDecided1 HDecided2).
+    assumption.
+  Qed.
+
   (** The following is an attempt to include finality in the definition of consistency by dropping the requirement
       that (j <> k). **)
 
-  Definition final_and_consistent : Prop :=
-      forall (tr : protocol_trace X),
-      forall (n1 n2 : nat),
-      forall (j k : index),
-      forall (s1 s2 : @state _ (composite_type IT)),
-      forall (c1 c2 : C),
-      trace_nth (proj1_sig tr) n1 = (Some s1) ->
-      trace_nth (proj1_sig tr) n2 = (Some s2) ->
-      (ID j) (s1 j) = (Some c1) ->
-      (ID k) (s2 k) = (Some c2) ->
-      c1 = c2.
+  Definition final_and_consistent :=
+      forall
+        (s1 s2 : @state _ (composite_type IT))
+        (Hfuture : in_futures X s1 s2)
+        (j k : index)
+        (c1 c2 : C)
+        (HDecided1 : (ID j) (s1 j) = Some c1)
+        (HDecided2 : (ID k) (s2 k) = Some c2)
+        , c1 = c2.
 
-  Lemma final_and_consistent_implies_final :
-      final_and_consistent ->
-      forall i : index, final (composite_vlsm_constrained_projection Hi IM constraint i) (ID i).
-
+  Lemma final_and_consistent_implies_final
+      (Hcons : final_and_consistent)
+      (i : index)
+      (Hfr : finite_projection_friendly Hi IM constraint i)
+      : final (composite_vlsm_constrained_projection Hi IM constraint i) (ID i)
+      .
   Proof.
-    unfold final_and_consistent.
-    intros.
-    unfold final.
-    intros.
-    Admitted.
+    intros s1 s2 c1 c2 Hfuturesi HD1 HD2.
+    specialize (projection_friendly_in_futures Hi IM constraint i Hfr s1 s2 Hfuturesi)
+    ; intros [sX1 [sX2 [Hs1 [Hs2 HfuturesX]]]].
+    subst.
+    apply (Hcons sX1 sX2 HfuturesX i i c1 c2 HD1 HD2).
+  Qed.
+
+  Lemma final_and_consistent_implies_consistent
+      (Hcons : final_and_consistent)
+      : consistent.
+  Proof.
+    unfold consistent; intros.
+    apply (Hcons s1 s2 Hfuture j k c1 c2 HDecided1 HDecided2).
+  Qed.
 
   Definition live :=
     forall (tr : @Trace _ (type X)),
@@ -160,15 +224,13 @@ End CommuteIndexed.
 Section Estimators.
   Context
     {CV : consensus_values}
-    {index : Set}
-    {index_listing : list index}
-    (finite_index : Listing index_listing)
-    {Heqd : EqDec index}
     {message : Type}
-    {IT : index -> VLSM_type message}
-    (IS : forall i : index, VLSM_sign (IT i))
-    (IM : forall i : index, VLSM (IS i))
+    {index : Type}
+    {Heqd : EqDec index}
     (Hi : index)
+    {IT : index -> VLSM_type message}
+    {IS : forall i : index, VLSM_sign (IT i)}
+    (IM : forall i : index, VLSM (IS i))
     (constraint : composite_label IT -> composite_state IT * option message -> Prop)
     (X := composite_vlsm Hi IM constraint)
     (ID : forall i : index, decision (IT i))
@@ -179,13 +241,11 @@ Section Estimators.
     (Xi := composite_vlsm_constrained_projection Hi IM constraint i)
     (Ei := @estimator _ _ (IE i))
     := forall
-      (psigma : protocol_state Xi)
-      (sigma := proj1_sig psigma)
+      (sigma : @state _ (IT i))
       (c : C)
       (HD : ID i sigma = Some c)
-      (psigma' : protocol_state Xi)
-      (sigma' := proj1_sig psigma')
-      (Hreach : in_futures Xi psigma psigma')
+      (sigma' : @state _ (IT i))
+      (Hreach : in_futures Xi sigma sigma')
       (c' : C),
       Ei sigma' c'
       -> c' = c.
@@ -200,10 +260,10 @@ Section Estimators.
       c_other = c.
   Proof.
     intros.
+    destruct s as [s Hs].
     unfold decision_estimator_property in H.
-    apply H with (psigma := s) (psigma':= s).
-    assumption.
-    apply in_futures_reflexive.
+    apply H with (sigma := s) (sigma':= s); try assumption.
+    apply in_futures_refl.
     assumption.
   Qed.
 
@@ -221,12 +281,12 @@ Section Estimators.
       apply estimator_total.
     }
     destruct H1.
+    destruct s as [s Hs].
     assert (x = c). {
-      apply H with (psigma := s) (psigma' := s).
+      apply H with (sigma := s) (sigma' := s); try assumption.
+      apply in_futures_refl.
       assumption.
-      apply in_futures_reflexive.
-      auto.
-   }
+    }
     rewrite <- H2.
     assumption.
    Qed.
@@ -250,16 +310,16 @@ Section Estimators.
     intros.
     unfold final.
     intros.
-    apply estimator_only_has_decision with (i := i) (s := s2).
+    specialize (in_futures_protocol_snd Xi s1 s2 H0); intro Hps2.
+    apply estimator_only_has_decision with (i := i) (s := (exist _ s2 Hps2)).
     assumption.
     assumption.
     unfold decision_estimator_property in H.
     assert(c2 = c1). {
-      apply H with (psigma := s1) (psigma' := s2).
+      apply H with (sigma := s1) (sigma' := s2).
       assumption.
       assumption.
-      apply estimator_surely_has_decision.
-      assumption.
+      apply (estimator_surely_has_decision i H (exist _ s2 Hps2)).
       assumption.
     }
     rewrite <- H3.

--- a/VLSM/ProjectionTraces.v
+++ b/VLSM/ProjectionTraces.v
@@ -7,6 +7,8 @@ Require Import Coq.Logic.FinFun Coq.Logic.Eqdep.
 From CasperCBC
      Require Import Lib.StreamExtras Lib.ListExtras Lib.Preamble VLSM.Common VLSM.Composition.
 
+Section ProjectionTraces.
+
 Context
   {message : Type}
   {index : Type}
@@ -15,16 +17,14 @@ Context
   {IT : index -> VLSM_type message}
   {IS : forall i : index, VLSM_sign (IT i)}
   (IM : forall n : index, VLSM (IS n))
-  (T := composite_type IT)
-  (S := composite_sig i0 IS)
-  (constraint : @label _ T -> @state _ T * option message -> Prop)
+  (constraint : @label _ (composite_type IT) -> @state _ (composite_type IT) * option message -> Prop)
   (X := composite_vlsm i0 IM constraint)
   (j : index)
   (Xj := composite_vlsm_constrained_projection i0 IM constraint j)
   .
 
 Fixpoint finite_trace_projection_list
-  (trx : list (@transition_item _ T))
+  (trx : list (@transition_item _ (type X)))
   : list (@transition_item _ (type Xj))
   :=
   match trx with
@@ -43,7 +43,7 @@ Fixpoint finite_trace_projection_list
   end.
 
 Definition from_projection
-  (a : @transition_item _ T)
+  (a : @transition_item _ (type X))
   : Prop
   := j = projT1 (l a).
 
@@ -53,12 +53,12 @@ Definition dec_from_projection
   := eq_dec j (projT1 (l a)).
 
 Definition finite_trace_projection_list_alt
-  (trx : list (@transition_item _ T))
+  (trx : list (@transition_item _ (type X)))
   (ftrx := (filter (predicate_to_function dec_from_projection) trx))
   (Hall: Forall from_projection ftrx)
   :=
   List.map
-    (fun item : {a : @transition_item _ T | from_projection a} =>
+    (fun item : {a : @transition_item _ (type X) | from_projection a} =>
       let (item, e) := item in
       let lj := eq_rect_r _ (projT2 (l item)) e in
       @Build_transition_item _ (type Xj)
@@ -70,7 +70,7 @@ Definition finite_trace_projection_list_alt
   (list_annotate from_projection ftrx Hall).
 
 Lemma finite_trace_projection_list_alt_iff
-  (trx : list (@transition_item _ T))
+  (trx : list (@transition_item _ (type X)))
   (ftrx := (filter (predicate_to_function dec_from_projection) trx))
   (Hall: Forall from_projection ftrx)
   : finite_trace_projection_list_alt trx Hall = finite_trace_projection_list trx.
@@ -121,11 +121,11 @@ Proof.
 Qed.
 
 Lemma finite_trace_projection_empty
-  (s : @state _ T)
-  (trx : list (@transition_item _ T))
+  (s : @state _ (type X))
+  (trx : list (@transition_item _ (type X)))
   (Htr : finite_protocol_trace_from X s trx)
   (Hempty : finite_trace_projection_list trx = [])
-  (t : (@transition_item _ T))
+  (t : (@transition_item _ (type X)))
   (Hin : In t trx)
   : destination t j = s j.
 Proof.
@@ -146,8 +146,8 @@ Proof.
 Qed.
 
 Lemma finite_trace_projection_last_state
-  (start : @state _ T)
-  (transitions : list (@transition_item _ T))
+  (start : @state _ (type X))
+  (transitions : list (@transition_item _ (type X)))
   (Htr : finite_protocol_trace_from X start transitions)
   (lstx := last (List.map destination transitions) start)
   (lstj := last (List.map destination (finite_trace_projection_list transitions)) (start j))
@@ -174,9 +174,9 @@ Qed.
 (* The projection of a finite protocol trace remains a protocol trace *)
 
 Lemma finite_ptrace_projection
-  (s : @state _ T)
+  (s : @state _ (type X))
   (Psj : protocol_state_prop Xj (s j))
-  (trx : list (@transition_item _ T))
+  (trx : list (@transition_item _ (type X)))
   (Htr : finite_protocol_trace_from X s trx)
    : finite_protocol_trace_from Xj (s j) (finite_trace_projection_list trx).
 Proof.
@@ -266,26 +266,60 @@ Proof.
   specialize (finite_trace_projection_last_state start transitions Htrace)
   ; simpl; intro Hlast.
   clear - Hlast Hps.
-  unfold T in Hlast; simpl in Hlast.
-  rewrite <- Hlast.
+  simpl in Hlast.
+  replace 
+    (@last (@_composite_state message index IT)
+      (@List.map
+         (@transition_item message (@composite_type message index IT))
+         (@_composite_state message index IT)
+         (@destination message (@composite_type message index IT))
+         transitions
+      ) start j
+    )
+    with
+    (@last (@state message (IT j))
+              (@List.map (@transition_item message (IT j))
+                 (@state message (IT j)) (@destination message (IT j))
+                 (finite_trace_projection_list transitions)) 
+              (start j))
+    .
+  assumption.
+Qed.
+
+Lemma in_futures_projection
+  (s1 s2 : state)
+  (Hfutures : in_futures X s1 s2)
+  : in_futures Xj (s1 j) (s2 j)
+  .
+Proof.
+  specialize (in_futures_protocol_fst X s1 s2 Hfutures)
+  ; intros HpsX1.
+  specialize (protocol_state_projection s1 HpsX1)
+  ; intros Hps1j.
+  destruct Hfutures as [tr [Htr Hs2]].
+  specialize (finite_ptrace_projection s1 Hps1j tr Htr); intros Htrj.
+  exists (finite_trace_projection_list tr).
+  split; try assumption.
+  subst s2.
+  apply finite_trace_projection_last_state.
   assumption.
 Qed.
 
 Definition in_projection
-   (tr : Stream (@transition_item _ T))
+   (tr : Stream (@transition_item _ (type X)))
    (n : nat)
    := from_projection (Str_nth n tr)
    .
 
 Definition in_projection_dec
-  := forall (tr : Stream (@transition_item _ T)),
+  := forall (tr : Stream (@transition_item _ (type X))),
        bounding (in_projection tr)
        + { ss : monotone_nat_stream
          | filtering_subsequence from_projection tr ss
          }.
 
 Definition infinite_trace_projection_stream
-  (ss: Stream (@transition_item _ T))
+  (ss: Stream (@transition_item _ (type X)))
   (ks: monotone_nat_stream)
   (Hfilter: filtering_subsequence from_projection ss ks)
   : Stream (@transition_item _ (IT j))
@@ -294,7 +328,7 @@ Definition infinite_trace_projection_stream
   let HForAll := stream_filter_Forall from_projection ss ks Hfilter in
   let subsP := stream_annotate from_projection subs HForAll in
   Streams.map
-    (fun item : {a : @transition_item _ T | from_projection a} =>
+    (fun item : {a : @transition_item _ (type X) | from_projection a} =>
       let (item, e) := item in
       let lj := eq_rect_r _ (projT2 (l item)) e in
       @Build_transition_item _ (type Xj) lj (input item) (destination item j) (output item)
@@ -302,7 +336,7 @@ Definition infinite_trace_projection_stream
     subsP.
 
 Lemma finite_trace_projection_stream
-  (ss: Stream (@transition_item _ T))
+  (ss: Stream (@transition_item _ (type X)))
   (ks: monotone_nat_stream)
   (Hfilter: filtering_subsequence from_projection ss ks)
   (n : nat)
@@ -325,18 +359,18 @@ Proof.
   assert
     (Heq' :
       (@stream_prefix
-        (@sig (@transition_item message T)
-          (fun a : @transition_item message T => from_projection a))
-        (@stream_annotate (@transition_item message T) from_projection
-          (@stream_subsequence (@transition_item message T) ss ks)
-          (@stream_filter_Forall (@transition_item message T) from_projection
+        (@sig (@transition_item message (type X))
+          (fun a : @transition_item message (type X) => from_projection a))
+        (@stream_annotate (@transition_item message (type X)) from_projection
+          (@stream_subsequence (@transition_item message (type X)) ss ks)
+          (@stream_filter_Forall (@transition_item message (type X)) from_projection
               ss ks Hfilter)) (succ n))
       =
       (@stream_prefix
-        (@sig (@transition_item message T) from_projection)
-        (@stream_annotate (@transition_item message T) from_projection
-          (@stream_subsequence (@transition_item message T) ss ks)
-          (@stream_filter_Forall (@transition_item message T) from_projection
+        (@sig (@transition_item message (type X)) from_projection)
+        (@stream_annotate (@transition_item message (type X)) from_projection
+          (@stream_subsequence (@transition_item message (type X)) ss ks)
+          (@stream_filter_Forall (@transition_item message (type X)) from_projection
               ss ks Hfilter)) (succ n))
     ) by reflexivity.
     rewrite Heq'.
@@ -362,7 +396,7 @@ Qed.
 
 Definition trace_projection
   (Hproj_dec : in_projection_dec)
-  (tr : @Trace _ T)
+  (tr : @Trace _ (type X))
   : @Trace _ (IT j).
 destruct tr as [s ls | s ss].
 - exact (Finite (s j) (finite_trace_projection_list ls)).
@@ -374,7 +408,7 @@ Defined.
 
 Lemma trace_projection_initial_state
   (Hproj_dec : in_projection_dec)
-  (tr : @Trace _ T)
+  (tr : @Trace _ (type X))
   : trace_first (trace_projection Hproj_dec tr)
   = trace_first tr j
   .
@@ -387,7 +421,7 @@ Proof.
 Qed.
 
 Lemma infinite_ptrace_projection
-  (s: @state _ T)
+  (s: @state _ (type X))
   (ss: Stream transition_item)
   (Psj: protocol_state_prop Xj (s j))
   (Htr: infinite_protocol_trace_from X s ss)
@@ -409,7 +443,7 @@ Qed.
 
 Lemma ptrace_from_projection
   (Hproj_dec : in_projection_dec)
-  (tr : @Trace _ T)
+  (tr : @Trace _ (type X))
   (Psj : protocol_state_prop Xj (trace_first tr j))
   (Htr : ptrace_from_prop X tr)
    : ptrace_from_prop Xj (trace_projection Hproj_dec tr).
@@ -425,7 +459,7 @@ Qed.
 
 Lemma protocol_trace_projection
   (Hproj_dec : in_projection_dec)
-  (tr : @Trace _ T)
+  (tr : @Trace _ (type X))
   (Htr : protocol_trace_prop X tr)
   : protocol_trace_prop Xj (trace_projection Hproj_dec tr).
 Proof.
@@ -450,7 +484,7 @@ Definition finite_projection_friendly
     (sj : @state _ (IT j))
     (trj : list (@transition_item _ (IT j)))
     (Htrj : finite_protocol_trace Xj sj trj),
-    exists (sx : @state _ T) (trx : list (@transition_item _ T)),
+    exists (sx : @state _ (type X)) (trx : list (@transition_item _ (type X))),
       finite_protocol_trace X sx trx
       /\ sx j = sj
       /\ finite_trace_projection_list trx = trj.
@@ -460,7 +494,7 @@ Definition projection_friendly
   := forall
   (trj : @Trace _ (IT j))
   (Htrj : protocol_trace_prop Xj trj),
-  exists (tr : @Trace _ T),
+  exists (tr : @Trace _ (type X)),
     protocol_trace_prop X tr
     /\ trace_projection Hproj_dec tr = trj.
 
@@ -487,3 +521,224 @@ Proof.
     apply infinite_protocol_trace_from_prefix.
     assumption.
 Qed.
+
+Lemma projection_friendly_in_futures'
+  (sx: state)
+  (trx: list transition_item)
+  (Htrx: finite_protocol_trace X sx trx)
+  (sj: state)
+  (Hsx: sx j = sj)
+  (Hall: Forall from_projection
+         (filter (predicate_to_function dec_from_projection) trx))
+  (s1 s2: state)
+  (n1 n2: nat)
+  (Hle: n1 <= n2)
+  (Hs1: nth_error
+        (sj
+         :: List.map destination (finite_trace_projection_list_alt trx Hall))
+        n1 = Some s1)
+  (Hs2: nth_error
+        (sj
+         :: List.map destination (finite_trace_projection_list_alt trx Hall))
+        n2 = Some s2)
+  : exists sX1 sX2 : @state _ (type X), sX1 j = s1 /\ sX2 j = s2 /\ in_futures X sX1 sX2
+  .
+Proof.
+    assert (HsX1 : exists (nX1 nX2 : nat) (sX1 sX2 : @state _ (type X)), nX1 <= nX2 /\ sX1 j = s1 /\ sX2 j = s2 /\ nth_error (sx :: List.map destination trx) nX1 = Some sX1 /\ nth_error (sx :: List.map destination trx) nX2 = Some sX2).
+    {
+      destruct n1; destruct n2.
+      - exists 0; exists 0; exists sx; exists sx
+        ; inversion Hs1; inversion Hs2; subst; repeat split; assumption.
+      - exists 0; inversion Hs1; clear Hs1; subst.
+        simpl in Hs2.
+        rewrite nth_error_map in Hs2.
+        unfold finite_trace_projection_list_alt in Hs2.
+        rewrite nth_error_map in Hs2.
+        specialize
+          (nth_error_list_annotate
+            from_projection
+            (filter (predicate_to_function dec_from_projection) trx)
+            Hall
+            n2
+          ); intros [oitem [Hoa Hnth]].
+        replace
+          (@nth_error
+            (@sig (@transition_item message (type X))
+               (fun a : @transition_item message (type X) => from_projection a))
+            (@list_annotate (@transition_item message (type X)) from_projection
+               (@filter (@transition_item message (type X))
+                  (@predicate_to_function (@transition_item message (type X))
+                     from_projection dec_from_projection) trx) Hall) n2
+          ) with oitem in Hs2.
+        clear Hoa.
+        destruct oitem as [[item Hitem]|]; try inversion Hs2; subst; clear Hs2.
+        simpl in Hnth.
+        symmetry in Hnth.
+        apply nth_error_filter in Hnth.
+        destruct Hnth as [nX2 [Hindex Hnth]].
+        exists (S nX2).
+        exists sx.
+        exists (destination item).
+        repeat split; try assumption.
+        + apply le_0_n.
+        + simpl. rewrite nth_error_map. replace (nth_error trx nX2) with (Some item).
+          reflexivity.
+      - inversion Hle.
+      - simpl in Hs1. simpl in Hs2.
+        rewrite nth_error_map in Hs1.
+        rewrite nth_error_map in Hs2.
+        unfold finite_trace_projection_list_alt in Hs1.
+        unfold finite_trace_projection_list_alt in Hs2.
+        rewrite nth_error_map in Hs1.
+        rewrite nth_error_map in Hs2.
+        specialize
+          (nth_error_list_annotate
+            from_projection
+            (filter (predicate_to_function dec_from_projection) trx)
+            Hall
+            n2
+          ); intros [oitem2 [Hoa2 Hn2th]].
+        specialize
+          (nth_error_list_annotate
+            from_projection
+            (filter (predicate_to_function dec_from_projection) trx)
+            Hall
+            n1
+          ); intros [oitem1 [Hoa1 Hn1th]].
+        replace
+          (@nth_error
+            (@sig (@transition_item message (type X))
+               (fun a : @transition_item message (type X) => from_projection a))
+            (@list_annotate (@transition_item message (type X)) from_projection
+               (@filter (@transition_item message (type X))
+                  (@predicate_to_function (@transition_item message (type X))
+                     from_projection dec_from_projection) trx) Hall) n2
+          ) with oitem2 in Hs2.
+        clear Hoa2.
+        replace
+          (@nth_error
+            (@sig (@transition_item message (type X))
+               (fun a : @transition_item message (type X) => from_projection a))
+            (@list_annotate (@transition_item message (type X)) from_projection
+               (@filter (@transition_item message (type X))
+                  (@predicate_to_function (@transition_item message (type X))
+                     from_projection dec_from_projection) trx) Hall) n1
+          ) with oitem1 in Hs1.
+        clear Hoa1.
+        destruct oitem2 as [[item2 Hitem2]|]; try inversion Hs2; subst; clear Hs2.
+        destruct oitem1 as [[item1 Hitem1]|]; try inversion Hs1; subst; clear Hs1.
+        simpl in Hn1th.
+        simpl in Hn2th.
+        symmetry in Hn1th.
+        symmetry in Hn2th.
+        apply nth_error_filter in Hn1th.
+        apply nth_error_filter in Hn2th.
+        destruct Hn2th as [nX2 [Hindex2 Hn2th]].
+        destruct Hn1th as [nX1 [Hindex1 Hn1th]].
+        exists (S nX1).
+        exists (S nX2).
+        exists (destination item1).
+        exists (destination item2).
+        repeat split; try assumption.
+        + apply le_n_S.
+          apply le_S_n in Hle.
+          specialize (nth_error_filter_index_le _ _ _ _ Hle _ _ Hindex1 Hindex2).
+          intro; assumption.
+        + simpl. rewrite nth_error_map. replace (nth_error trx nX1) with (Some item1).
+          reflexivity.
+        + simpl. rewrite nth_error_map. replace (nth_error trx nX2) with (Some item2).
+          reflexivity.
+    }
+    destruct HsX1 as [nX1 [nX2 [sX1 [sX2 [HleX [Hps1 [Hps2 [HsX1 HsX2]]]]]]]].
+    exists sX1. exists sX2. repeat split; try assumption.
+    specialize (in_futures_witness_reverse X sX1 sX2 (exist (protocol_trace_prop X) (Finite sx trx) Htrx) nX1 nX2 HleX HsX1 HsX2).
+    intros; assumption.
+Qed.
+
+Lemma projection_friendly_in_futures
+  (Hfr : finite_projection_friendly)
+  (s1 s2 : @state _ (IT j))
+  (Hfuture : in_futures Xj s1 s2)
+  : exists (sX1 sX2 : @state _ (type X)),
+    sX1 j = s1 /\ sX2 j = s2 /\ in_futures X sX1 sX2
+  .
+Proof.
+  specialize (in_futures_witness Xj s1 s2 Hfuture)
+  ; intros [trj [n1 [n2 [Hle [Hs1 Hs2]]]]].
+  clear Hfuture.
+  destruct trj as [trj Htrj].
+  specialize (trace_prefix_fn_protocol Xj trj Htrj n2); intros Hpref.
+  remember (trace_prefix_fn trj n2) as trj2.
+  destruct trj2 as [sj' lj' | sj' lj']; destruct trj as [sj lj | sj lj]
+  ; inversion Heqtrj2
+  ; subst sj' lj'.
+  - specialize (Hfr sj (list_prefix lj n2) Hpref).
+    destruct Hfr as [sx [trx [Htrx [Hsx Hproj]]]].
+    assert (Hall : Forall from_projection
+              (filter (predicate_to_function dec_from_projection) trx))
+      by apply filter_Forall.
+    specialize (finite_trace_projection_list_alt_iff trx Hall); intro Heq.
+    rewrite <- Heq in Hproj.
+    simpl in Hs1.
+    simpl in Hs2.
+    assert
+      (Hs1' :
+        nth_error (sj :: List.map destination lj) n1 =
+        nth_error (sj :: List.map destination (list_prefix lj n2)) n1
+      ).
+    { destruct n1; try reflexivity. simpl.
+      rewrite list_prefix_map.
+      symmetry. apply list_prefix_nth. assumption.
+    }
+    assert
+      (Hs2' :
+        nth_error (sj :: List.map destination lj) n2 =
+        nth_error (sj :: List.map destination (list_prefix lj n2)) n2
+      ).
+    { destruct n2; try reflexivity. simpl.
+      rewrite list_prefix_map.
+      symmetry. apply list_prefix_nth. constructor.
+    }
+    rewrite Hs1' in Hs1; clear Hs1'.
+    rewrite Hs2' in Hs2; clear Hs2'.
+    rewrite <- Hproj in Hs1.
+    rewrite <- Hproj in Hs2.
+    apply projection_friendly_in_futures' with sx trx sj Hall n1 n2; assumption.
+  - specialize (Hfr sj (stream_prefix lj n2) Hpref).
+    destruct Hfr as [sx [trx [Htrx [Hsx Hproj]]]].
+    assert (Hall : Forall from_projection
+              (filter (predicate_to_function dec_from_projection) trx))
+      by apply filter_Forall.
+    specialize (finite_trace_projection_list_alt_iff trx Hall); intro Heq.
+    rewrite <- Heq in Hproj.
+    simpl in Hs1.
+    simpl in Hs2.
+    assert
+      (Hs1' :
+        Some (Str_nth n1 (Cons sj (map destination lj))) =
+        nth_error (sj :: List.map destination (stream_prefix lj n2)) n1
+      ).
+    { destruct n1; try reflexivity. simpl.
+      rewrite stream_prefix_map.
+      rewrite stream_prefix_nth; try assumption.
+      reflexivity.
+    }
+    assert
+      (Hs2' :
+      Some (Str_nth n2 (Cons sj (map destination lj))) =
+        nth_error (sj :: List.map destination (stream_prefix lj n2)) n2
+      ).
+    { destruct n2; try reflexivity.
+      rewrite stream_prefix_map.
+      remember (S n2) as sn2. rewrite Heqsn2 at 3.
+      simpl.
+      rewrite stream_prefix_nth; subst; constructor.
+    }
+    rewrite Hs1' in Hs1; clear Hs1'.
+    rewrite Hs2' in Hs2; clear Hs2'.
+    rewrite <- Hproj in Hs1.
+    rewrite <- Hproj in Hs2.
+    apply projection_friendly_in_futures' with sx trx sj Hall n1 n2; assumption.
+Qed.
+
+End ProjectionTraces.

--- a/VLSM/ProjectionTraces.v
+++ b/VLSM/ProjectionTraces.v
@@ -1,5 +1,6 @@
 Require Import List Streams Nat Bool.
 Import ListNotations.
+Require Import Lia.
 Require Import Logic.FunctionalExtensionality.
 
 Require Import Coq.Logic.FinFun Coq.Logic.Eqdep.
@@ -579,10 +580,9 @@ Proof.
         exists (S nX2).
         exists sx.
         exists (destination item).
-        repeat split; try assumption.
-        + apply le_0_n.
-        + simpl. rewrite nth_error_map. replace (nth_error trx nX2) with (Some item).
-          reflexivity.
+        repeat split; try lia.
+        simpl. rewrite nth_error_map. replace (nth_error trx nX2) with (Some item).
+        reflexivity.
       - inversion Hle.
       - simpl in Hs1. simpl in Hs2.
         rewrite nth_error_map in Hs1.
@@ -640,10 +640,9 @@ Proof.
         exists (destination item1).
         exists (destination item2).
         repeat split; try assumption.
-        + apply le_n_S.
-          apply le_S_n in Hle.
-          specialize (nth_error_filter_index_le _ _ _ _ Hle _ _ Hindex1 Hindex2).
-          intro; assumption.
+        + assert (Hle' : n1 <= n2) by lia.
+          specialize (nth_error_filter_index_le _ _ _ _ Hle' _ _ Hindex1 Hindex2).
+          intro; lia.
         + simpl. rewrite nth_error_map. replace (nth_error trx nX1) with (Some item1).
           reflexivity.
         + simpl. rewrite nth_error_map. replace (nth_error trx nX2) with (Some item2).

--- a/_CoqProject
+++ b/_CoqProject
@@ -4,6 +4,7 @@ VLSM/Common.v
 VLSM/Composition.v
 VLSM/Decisions.v
 VLSM/ProjectionTraces.v
+VLSM/CommonFutures.v
 VLSM/Validating.v
 VLSM/ByzantineTraces.v
 VLSM/FullNode.v


### PR DESCRIPTION
Common futures
* Definition for common futures (estimates)
* Proof the common futures implies consistency and finality of decisions on consensus values

Consistency definitions
* gave an alternate definition for consistency based on in_futures; proved it equivalent with original
* derived an consistent_and_final definition from consistency by removing i<> j condition
* proved that consistent_and_final always implies consistent but only implies final under projection friendliness assumptions
  - proved that `in_futures` is an order relation (reflexive & transitive)
  - proved that `in_futures` in composition implies `in_futures` in projection
  - proved that `in_futures` in projection implies `in_futures` in  composition under projection friendliness assumptions.

Studying a sufficient condition for projection friendliness
* if `protocol_valid lj (sj, om)`  in Xj and `s` protocol state such that `s j = sj`, then `valid (j,lj) (s, om)` in X
* Defined "lifting" of a state / trace from a component to composition by using the initial state for all other components.
* showed that under given condition the lifting of a protocol trace from the projection is also protocol in the composition
