### PR TITLE
add task to build coq2html documentation and use in CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN    opam init --auto-setup --yes --jobs=${NJOBS} --compiler=${COMPILER} --dis
 # From: https://github.com/coq-community/docker-coq/blob/master/Dockerfile
 
 ENV COQ_VERSION="8.12.0"
-ENV COQ_EXTRA_OPAM="coq-bignums"
+ENV COQ_EXTRA_OPAM="coq-bignums coq-coq2html"
 
 RUN    eval $(opam env --switch=${COMPILER} --set-switch)   \
     && opam update -y -u                                    \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,6 +37,7 @@ pipeline {
           sh '''
             eval $(opam env)
             make -j 6 coqdoc
+            make -j 6 coq2html
             export COQ_SHA=$(git rev-parse HEAD)
 
             git clone 'ssh://github.com/runtimeverification/casper-cbc-proof-docs.git'
@@ -46,6 +47,7 @@ pipeline {
             mkdir docs/${COQ_SHA}
             cd docs
             cp -r ../../docs/coqdoc ${COQ_SHA}
+            cp -r ../../docs/coq2html ${COQ_SHA}
             ln -sfn ${COQ_SHA} latest
             cd ..
 

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -3,6 +3,8 @@ CSSFILES = resources/coqdoc.css resources/coqdocjs.css
 JSFILES = resources/config.js resources/coqdocjs.js
 HTMLFILES = resources/header.html resources/footer.html
 COQDOCDIR = docs/coqdoc
+COQ2HTML = coq2html
+COQ2HTMLDIR = docs/coq2html
 
 COQDOCHTMLFLAGS = --toc --toc-depth 2 --index indexpage --html -s \
   --interpolate --no-lib-name --parse-comments \
@@ -15,6 +17,14 @@ coqdoc: $(GLOBFILES) $(VFILES) $(CSSFILES) $(JSFILES) $(HTMLFILES)
 	$(SHOW)'COPY resources'
 	$(HIDE)cp $(CSSFILES) $(JSFILES) $(COQDOCDIR)
 .PHONY: coqdoc
+
+coq2html: $(GLOBFILES) $(VFILES)
+	$(SHOW)'COQ2HTML -d $(COQ2HTMLDIR)'
+	$(HIDE)mkdir -p $(COQ2HTMLDIR)
+	$(HIDE)cd Lib && $(COQ2HTML) -base CasperCBC.Lib -d ../$(COQ2HTMLDIR) *.v *.glob
+	$(HIDE)cd CBC && $(COQ2HTML) -base CasperCBC.CBC -d ../$(COQ2HTMLDIR) *.v *.glob
+	$(HIDE)cd VLSM && $(COQ2HTML) -base CasperCBC.VLSM -d ../$(COQ2HTMLDIR) *.v *.glob
+.PHONY: coq2html
 
 resources/index.html: resources/index.md
 	pandoc -s -o $@ $<


### PR DESCRIPTION
Unfortunately, the HTML will only be added to the static website when this PR is merged, but CI should tell us if something is wrong.