### PR TITLE
purging unused and superceded order classes

### DIFF
--- a/CBC/Binary.v
+++ b/CBC/Binary.v
@@ -107,7 +107,7 @@ Section States.
     set_map compare_eq_dec sender sigma.
 
   Parameters (hash : message -> H)
-             (hash_injective : Injective hash).
+             (hash_injective : Inj eq eq hash).
 
   Definition later (msg : message) (sigma : state) : list message :=
     filter (fun msg' => inb compare_eq_dec (hash msg) (justification msg')) sigma.

--- a/CBC/LightNode.v
+++ b/CBC/LightNode.v
@@ -18,7 +18,7 @@ Class MessageHash message hash :=
   }.
 
 Class InjectiveMessageHash message hash (Hmh : MessageHash message hash) :=
-  { hash_message_injective : Injective hash_message
+  { hash_message_injective : Inj eq eq hash_message
   }.
 
 Section LightNode_protocol_eq.

--- a/Lib/ListExtras.v
+++ b/Lib/ListExtras.v
@@ -296,15 +296,6 @@ Definition incl_correct `{EqDecision A}
   : incl l1 l2 <-> inclb l1 l2 = true
   := incl_function l1 l2.
 
-Lemma map_injective : forall A B (f : A -> B),
-  Injective f -> Injective (map f).
-Proof.
-  intros. intros xs ys. generalize dependent ys.
-  induction xs; intros; destruct ys; split; intros; try reflexivity; try discriminate.
-  - simpl in H0. inversion H0 . apply H in H2; subst. apply IHxs in H3; subst. reflexivity.
-  - rewrite H0. reflexivity.
-Qed.
-
 Lemma map_incl {A B} (f : B -> A) : forall s s',
   incl s s' ->
   incl (map f s) (map f s').

--- a/Lib/ListSetExtras.v
+++ b/Lib/ListSetExtras.v
@@ -382,16 +382,6 @@ Proof.
   - exfalso. inversion H1.
 Qed.
 
-Lemma set_map_injective {A B} `{EqDecision A} (f : B -> A) :
-  Injective f ->
-  forall s s',
-    set_eq (set_map decide_eq f s) (set_map decide_eq f s') -> set_eq s s'.
-Proof.
-  intros. split; intros x Hin;
-    apply (set_map_in f) in Hin; apply H0 in Hin; apply set_map_exists in Hin
-    ; destruct Hin as [x' [Hin Heq]]; apply H in Heq; subst; assumption.
-Qed.
-
 Lemma filter_set_add `{StrictlyComparable X} :
   forall (l : list X) (f : X -> bool) (x : X),
     f x = false ->

--- a/Lib/Preamble.v
+++ b/Lib/Preamble.v
@@ -165,15 +165,6 @@ Proof.
   - rewrite Hirrelevance at 1. reflexivity.
 Qed.
 
-Class TotalOrder {A} (lt : relation A) : Prop :=
-   totality : forall c1 c2, c1 = c2 \/ lt c1 c2 \/ lt c2 c1.
-
-Class Injective {A B} (f : A -> B) : Prop :=
-  injective : forall x y, f x = f y <-> x = y.
-
-Class Commutative {A B : Type} (f : A -> A -> B) :=
-  commutative : forall a1 a2, f a1 a2 = f a2 a1.
-
 Class DecidablePred {A} (r : A -> Prop) :=
   pred_dec : forall (a : A), r a \/ ~ r a.
 
@@ -339,18 +330,6 @@ Proof.
   intros x y Hxy Hyx. apply (TR _ _ _ _ Hxy) in Hyx.
   assert (compare x x = Eq) by (apply compare_eq; reflexivity).
   rewrite Hyx in H; discriminate.
-Qed.
-
-Lemma compare_lt_total_order {A} `{CompareStrictOrder A} :
-  TotalOrder (compare_lt compare).
-Proof.
-  intros x y.
-  assert (CSO := H).
-  destruct H as [R TR].
-  destruct (compare x y) eqn:Hcmp.
-  - apply R in Hcmp. left. assumption.
-  - right. left. assumption.
-  - right. right. now apply compare_asymmetric_intro.
 Qed.
 
 (* We can easily obtain inhabitants of above Typeclasses using Program Definitions, for instance : *)


### PR DESCRIPTION
The definition of `TotalOrder` in `Lib/Preamble.v` is buggy, so here I purge this and other obsolete type classes (and some related unused lemmas).