### PR TITLE
Simplify some proofs

### DIFF
--- a/Lib/Classes.v
+++ b/Lib/Classes.v
@@ -144,7 +144,16 @@ Coercion Is_true : bool >-> Sortclass.
 Hint Unfold Is_true : core.
 Hint Immediate Is_true_eq_left : core.
 Hint Resolve orb_prop_intro andb_prop_intro : core.
+Lemma Is_true_iff_eq_true: forall x: bool, x = true <-> x.
+Proof.
+  split. apply Is_true_eq_left. apply Is_true_eq_true.
+Qed.
 
+Definition bool_decision {b:bool} : Decision b :=
+  match b return {b}+{~b} with
+          | true => left I
+          | false => right (fun H => H)
+  end.
 (** ** Basic instances *)
 
 Instance prop_inhabited : Inhabited Prop := populate True.
@@ -287,3 +296,32 @@ Proof. solve_decision. Defined.
 
 Instance sum_eq_dec `{EqDecision A, EqDecision B} : EqDecision (A + B).
 Proof. solve_decision. Defined.
+
+(* Some relation facts *)
+Lemma Reflexive_reexpress_impl {A} (R S: Relation_Definitions.relation A):
+  relation_equivalence R S -> Reflexive R -> Reflexive S.
+Proof.
+  clear;firstorder.
+Qed.
+Lemma complement_equivalence {A}:
+  Morphisms.Proper (Morphisms.respectful relation_equivalence relation_equivalence) (@complement A).
+Proof.
+  clear;firstorder.
+Qed.
+Lemma Transitive_reexpress_impl {A} (R S: Relation_Definitions.relation A):
+  relation_equivalence R S -> Transitive R -> Transitive S.
+Proof.
+  clear.
+  unfold relation_equivalence, predicate_equivalence; simpl.
+  intros Hrel HtransR x y z.
+  rewrite <- !Hrel.
+  apply HtransR.
+Qed.
+Lemma StrictOrder_reexpress_impl {A} (R S: Relation_Definitions.relation A):
+  relation_equivalence R S -> StrictOrder R -> StrictOrder S.
+Proof.
+  clear.
+  intros Hrel [Hirr Htrans]. constructor.
+  revert Hirr;apply Reflexive_reexpress_impl. apply complement_equivalence. assumption.
+  revert Htrans;apply Transitive_reexpress_impl. assumption.
+Qed.

--- a/Lib/Classes.v
+++ b/Lib/Classes.v
@@ -149,7 +149,7 @@ Proof.
   split. apply Is_true_eq_left. apply Is_true_eq_true.
 Qed.
 
-Definition bool_decision {b:bool} : Decision b :=
+Instance bool_decision {b:bool} : Decision b :=
   match b return {b}+{~b} with
           | true => left I
           | false => right (fun H => H)

--- a/Lib/ListExtras.v
+++ b/Lib/ListExtras.v
@@ -275,11 +275,8 @@ Lemma in_correct_refl `{EqDecision X} :
     In x l <-> inb decide_eq x l.
 Proof.
   intros s msg.
-  split; intros.
-  - apply Is_true_eq_left.
-    apply in_correct; assumption.
-  - apply in_correct.
-    apply Is_true_eq_true; assumption.
+  rewrite in_correct, Is_true_iff_eq_true.
+  reflexivity.
 Qed.
 
 Lemma in_correct' `{EqDecision X} :
@@ -287,8 +284,8 @@ Lemma in_correct' `{EqDecision X} :
     ~ In x l <-> inb decide_eq x l = false.
 Proof.
   intros s msg.
-  symmetry. apply mirror_reflect_curry.
-  symmetry; now apply in_correct.
+  rewrite in_correct, not_true_iff_false.
+  reflexivity.
 Qed.
 
 Definition inclb

--- a/VLSM/FullNode/Composite/LimitedEquivocation.v
+++ b/VLSM/FullNode/Composite/LimitedEquivocation.v
@@ -246,16 +246,8 @@ Context
 
 Existing Instance message_events.
 
-Instance happens_before_rel : RelDecision happens_before_fn.
-Proof.
-unfold RelDecision; intros.
-unfold Decision.
-destruct (happens_before_fn x y) eqn:?.
-- apply left; reflexivity.
-- apply right.
-  intro H.
-  contradict H.
-Defined.
+Instance happens_before_rel : RelDecision happens_before_fn :=
+  fun x y => bool_decision.
 
 Definition sorted_state_union
   (s : vstate FreeX)
@@ -756,22 +748,12 @@ Instance StrictOrder_preceeds_happens_before_fn :
 Proof.
 unfold preceeds_P; simpl.
 assert (Hstr: StrictOrder
- (fun x0 y : {x : State.message C V | byzantine_message_prop FreeX x} =>
-  validator_message_preceeds C V (proj1_sig x0) (proj1_sig y))).
-apply free_full_byzantine_message_preceeds_stict_order.
+ (fun x y => validator_message_preceeds C V (proj1_sig x) (proj1_sig y)))
+       by apply free_full_byzantine_message_preceeds_stict_order.
 unfold validator_message_preceeds in Hstr.
-destruct Hstr.
-constructor.
-* intro x'; specialize (StrictOrder_Irreflexive x').
-  generalize StrictOrder_Irreflexive.
-  unfold complement; simpl; intros.
-  apply StrictOrder_Irreflexive0.
-  apply Bool.Is_true_eq_true.
-  assumption.
-* intros x' y' z'. specialize (StrictOrder_Transitive x' y' z').
-  generalize StrictOrder_Transitive; intros.
-  apply Bool.Is_true_eq_left.
-  apply StrictOrder_Transitive0; apply Bool.Is_true_eq_true; assumption.
+revert Hstr.
+apply StrictOrder_reexpress_impl. intros x y;simpl.
+split;[apply Bool.Is_true_eq_left|apply Bool.Is_true_eq_true].
 Qed.
 
 Lemma receive_messages_protocol
@@ -823,7 +805,7 @@ Proof.
       assumption.
     + assert (Hx : In x (ms ++ [x])).
         { apply in_app_iff. right. left. reflexivity. }
-      simpl. 
+      simpl.
       destruct i as [v | client]; simpl; repeat split
       ; try
         (intro Hx'


### PR DESCRIPTION
Some new proofs from Karl's changes to use Is_true had chunks
that were really inlining arguments for more general claims,
about Is_true or that relation properties like StrictOrder
must hold for one relation iff they hold for an extensionally
equivalent relation. I extracted these proof.

Also has some other changes that just shorten proofs without
extracting any lemmas, and removes some trailing whitespace.