### PR TITLE
Remove the bad notation for Msg

### DIFF
--- a/CBC/FullNode/Validator/Equivocation.v
+++ b/CBC/FullNode/Validator/Equivocation.v
@@ -47,9 +47,7 @@ Definition validator_message_preceeds_fn
   (m1 m2 : State.message C V)
   : bool
   :=
-  match m2 with
-  | (c, v, j) => inb decide_eq m1 (get_message_set (unmake_justification j))
-  end.
+  let (c, v, j) := m2 in inb decide_eq m1 (get_message_set (unmake_justification j)).
 
 Definition validator_message_preceeds
   (m1 m2 : State.message C V)
@@ -68,27 +66,27 @@ Lemma  validator_message_preceeds_irreflexive'
   (v : V)
   (j1 j2 : justification C V)
   (Hincl : justification_incl j2 j1)
-  : ~inb decide_eq ((c, v, j1)) (get_message_set (unmake_justification j2)) = true.
+  : ~inb decide_eq (Msg c v j1) (get_message_set (unmake_justification j2)) = true.
 Proof.
   generalize dependent j1.
   generalize dependent v.
   generalize dependent c.
   apply
-    (justification_mut_ind C V
+    (justification_mut_ind
       (fun j2 =>
         forall (c : C) (v : V) (j1 : justification C V),
         justification_incl j2 j1 ->
-        inb decide_eq ((c, v, j1)) (get_message_set (unmake_justification j2)) <> true
+        inb decide_eq (Msg c v j1) (get_message_set (unmake_justification j2)) <> true
       )
       (fun m =>
         forall (c : C) (v : V) (j1 : justification C V),
         justification_incl (get_justification m) j1 ->
-        inb decide_eq ((c, v, j1)) (get_message_set (unmake_justification (get_justification m))) <> true
+        inb decide_eq (Msg c v j1) (get_message_set (unmake_justification (get_justification m))) <> true
       )
       (fun msgs =>
         forall (c : C) (v : V) (j1 : justification C V),
         message_set_incl msgs (justification_message_set j1) ->
-        inb decide_eq ((c, v, j1)) (unmake_message_set msgs) <> true
+        inb decide_eq (Msg c v j1) (unmake_message_set msgs) <> true
       )
     ); simpl; intros; intro Hin; try discriminate.
   - specialize (H c v j1 H0).
@@ -100,7 +98,7 @@ Proof.
   - specialize
       (in_correct
         (set_add decide_eq m (unmake_message_set m0))
-        (Msg _ _ c v j1)
+        (Msg c v j1)
       ); intro Hin_in
     ; apply proj2 in Hin_in
     ;  apply Hin_in in Hin; clear Hin_in
@@ -112,7 +110,7 @@ Proof.
       specialize
         (in_correct
           (unmake_message_set (justification_message_set j1))
-          (Msg _ _ c v j1)
+          (Msg c v j1)
         ); intro Hin_in
       ; apply proj1 in Hin_in.
       apply Hin_in.

--- a/VLSM/FullNode/Composite/Free.v
+++ b/VLSM/FullNode/Composite/Free.v
@@ -393,7 +393,7 @@ Proof.
   specialize
     (in_correct
       (get_message_set (unmake_justification jy))
-      ((cx, vx, jx))
+      (Msg cx vx jx)
     ); intro Hin_in
   ; apply proj2 in Hin_in
   ; apply Hin_in in Hxy; clear Hin_in.
@@ -402,7 +402,7 @@ Proof.
   specialize
     (in_correct
       (get_message_set (unmake_justification jz))
-      ((cx, vx, jx))
+      (Msg cx vx jx)
     ); intro Hin_in
   ; apply proj1 in Hin_in
   ; apply Hin_in; clear Hin_in.

--- a/VLSM/FullNode/Composite/LimitedEquivocation.v
+++ b/VLSM/FullNode/Composite/LimitedEquivocation.v
@@ -1250,7 +1250,7 @@ Proof.
   destruct m as (cm, vm, jm).
   specialize (in_correct (unmake_message_set (justification_message_set jm)) mj); intro Hin.
   apply Hin in Hmj.
-  pose (in_free_byzantine_state_justification s Hs' ((cm, vm, jm))) as Hinm.
+  pose (in_free_byzantine_state_justification s Hs' (Msg cm vm jm)) as Hinm.
   destruct Hm as [[v Hm] | [client Hm]].
   - specialize (Hinm (inl v) Hm mj Hmj). left. exists v. assumption.
   - specialize (Hinm (inr client) Hm mj Hmj). right. exists client. assumption.

--- a/VLSM/FullNode/Validator.v
+++ b/VLSM/FullNode/Validator.v
@@ -95,7 +95,7 @@ Section CompositeValidator.
              | Some msg => pair (pair (set_add decide_eq msg msgs) final) None
            end
     | Some c =>
-      let msg := (c, v, make_justification s) in
+      let msg := Msg c v (make_justification s) in
       pair (pair (set_add decide_eq msg msgs) (Some msg)) (Some msg)
     end.
 
@@ -576,14 +576,14 @@ Section proper_sent_received.
     - inversion Ht; subst. destruct final as [m|]; clear Ht.
       + elim
         (in_justification_recursive'
-          ((c, v, LastSent C V (make_message_set msgs) m))
+          (Msg c v (LastSent (make_message_set msgs) m))
           msgs
           eq_refl
         ).
         assumption.
       + elim
         (in_justification_recursive'
-          ((c, v, NoSent C V (make_message_set msgs)))
+          (Msg c v (NoSent (make_message_set msgs)))
           msgs
           eq_refl
         ).


### PR DESCRIPTION
The notation "( c , v , j )" was making it impossible to use
simple parentheses for grouping.