### PR TITLE
Try to prevent diverging typeclass search

### DIFF
--- a/CBC/Common.v
+++ b/CBC/Common.v
@@ -8,6 +8,7 @@ Class InhabitedTwice V := { inhabited_twice : exists (v1 v2 : V), v1 <> v2 }.
 Definition pos_R := {r : R | (r > 0)%R}.
 
 Class Measurable V := { weight : V -> pos_R}.
+Hint Mode Measurable ! : typeclass_instances.
 
 Definition sum_weights `{Measurable V} (l : list V) : R :=
   fold_right (fun v r => (proj1_sig (weight v) + r)%R) 0%R l.
@@ -24,7 +25,7 @@ Qed.
 
 Class ReachableThreshold V `{Hm : Measurable V} :=
   { threshold : {r | (r >= 0)%R}
-  ; reachable_threshold : exists vs, NoDup vs /\ (sum_weights vs > (proj1_sig threshold))%R
+  ; reachable_threshold : exists (vs:list V), NoDup vs /\ (sum_weights vs > (proj1_sig threshold))%R
   }.
 
 Class DistinctChoice V `{HscV : StrictlyComparable V} `{Hit : InhabitedTwice V}.
@@ -71,7 +72,7 @@ Coercion weight_proj1_sig : pos_R >-> R.
 
 Lemma sum_weights_in
   `{EqDecision V} `{Hm : Measurable V}
-  : forall v vs,
+  : forall v (vs:list V),
   NoDup vs ->
   In v vs ->
   sum_weights vs = (proj1_sig (weight v) + sum_weights (set_remove decide_eq v vs))%R.
@@ -87,7 +88,7 @@ Qed.
 
 Lemma sum_weights_incl
   `{EqDecision V} `{Hm : Measurable V}
-  : forall vs vs',
+  : forall (vs vs':list V),
   NoDup vs ->
   NoDup vs' ->
   incl vs vs' ->
@@ -123,7 +124,7 @@ Qed.
 
 Lemma sum_weights_app
   `{Hm : Measurable V}
-  : forall vs vs',
+  : forall (vs vs':list V),
   sum_weights (vs ++ vs') = (sum_weights vs + sum_weights vs')%R.
 Proof.
   induction vs; intros; simpl.

--- a/CBC/Definitions.v
+++ b/CBC/Definitions.v
@@ -109,7 +109,7 @@ Instance state_type
   {C} `{about_C : StrictlyComparable C} {V} `{about_V : StrictlyComparable V}
   : StrictlyComparable state :=
   {
-    inhabited := state_inhabited;
+    inhabited := @state_inhabited C V _ _;
     compare := state_compare;
     compare_strictorder := state_compare_strict_order;
   }.
@@ -452,8 +452,6 @@ Proof.
     + exfalso. apply (no_confusion_next_empty _ _ H).
     + apply no_confusion_next in H. destruct H; subst. apply Hj.
     + apply no_confusion_next in Heq. destruct Heq; subst.
-      assert (CompareTransitive message_compare) by
-          apply message_type.
       apply (compare_lt_transitive  _ _ _ Hlt) in Hlt2.
       clear Hlt.
       destruct msg1' as [(c1', v1') j1']. destruct msg3 as [(c3, v3) j3].
@@ -538,7 +536,7 @@ Proof.
   apply H1 in Hin'. rewrite get_messages_next in Hin'.
   destruct Hin'; try assumption; subst.
   exfalso.
-  assert (CompareReflexive message_compare) by apply message_type. apply (compare_lt_irreflexive _ Hlt).
+  apply (compare_lt_irreflexive _ Hlt).
 Qed.
 
 Lemma sorted_syntactic_state_inclusion
@@ -567,11 +565,10 @@ Proof.
     assert (Hlt1 : message_lt msg' msg1).
     { destruct Hin1; subst; try assumption.
       apply (locally_sorted_first msg) in H3; try assumption.
-      assert (CompareTransitive message_compare) by apply message_type.
       apply compare_lt_transitive with msg; assumption.
     }
     destruct H1in'; try assumption; subst.
-    exfalso. assert (CompareReflexive message_compare) by apply message_type. apply (compare_lt_irreflexive _ Hlt1).
+    exfalso. apply (compare_lt_irreflexive _ Hlt1).
 Qed.
 
 

--- a/Lib/ListExtras.v
+++ b/Lib/ListExtras.v
@@ -401,7 +401,8 @@ Definition compareb {A} `{StrictlyComparable A} (a1 a2 : A) : bool :=
   | _ => false
   end.
 
-Lemma is_member_correct {W} `{StrictlyComparable W} : forall l w, is_member w l = true <-> In w l.
+Lemma is_member_correct {W} `{StrictlyComparable W}
+  : forall l (w : W), is_member w l = true <-> In w l.
 Proof.
   intros l w.
   induction l as [|hd tl IHl].
@@ -428,7 +429,8 @@ Proof.
         assumption.
 Qed.
 
-Lemma is_member_correct' {W} `{StrictlyComparable W} : forall l w, is_member w l = false <-> ~ In w l.
+Lemma is_member_correct' {W} `{StrictlyComparable W}
+  : forall l (w : W), is_member w l = false <-> ~ In w l.
 Proof.
   intros.
   apply mirror_reflect.

--- a/Lib/Preamble.v
+++ b/Lib/Preamble.v
@@ -172,12 +172,15 @@ Qed.
 
 Class DecidablePred {A} (r : A -> Prop) :=
   pred_dec : forall (a : A), r a \/ ~ r a.
+Hint Mode DecidablePred ! ! : typeclass_instances.
 
 Class PredicateFunction {A} (r : A -> Prop) (r_fn : A -> bool) : Prop :=
   {
     equiv : forall a, r a <-> r_fn a = true;
     predicate_function_dec :> DecidablePred r;
   }.
+Hint Mode PredicateFunction ! ! - : typeclass_instances.
+Hint Mode PredicateFunction ! - ! : typeclass_instances.
 
 Definition predicate_not {A} (p : A -> Prop) : A -> Prop :=
   fun a => ~ p a.
@@ -194,6 +197,8 @@ Qed.
 
 Class PredicateFunction2 {A B} (r : A -> B -> Prop) (r_fn : A -> B -> bool) : Prop :=
   predicate_function2 : forall a b, r a b <-> r_fn a b = true.
+Hint Mode PredicateFunction2 ! ! ! - : typeclass_instances.
+Hint Mode PredicateFunction2 ! ! - ! : typeclass_instances.
 
 Lemma predicate_function2_neg : forall A B (r : A -> B -> Prop) (r_fn : A -> B -> bool),
   PredicateFunction2 r r_fn ->
@@ -224,6 +229,7 @@ Qed.
 (* Reflexivity of comparison operators *)
 Class CompareReflexive {A} (compare : A -> A -> comparison) : Prop :=
     compare_eq : forall x y, compare x y = Eq <-> x = y.
+Hint Mode CompareReflexive ! - : typeclass_instances.
 
 (* About reflexive comparison operators *)
 Lemma compare_eq_refl {A} `{CompareReflexive A} :
@@ -242,7 +248,7 @@ Lemma compare_lt_neq {A} `{CompareReflexive A} :
   forall x y, compare x y = Lt -> x <> y.
 Proof.
   intros x y Hcomp Hnot.
-  subst. now apply (compare_eq_lt y).
+  subst. now (apply (compare_eq_lt y) in Hcomp).
 Qed.
 
 Lemma compare_eq_gt {A} `{CompareReflexive A} :
@@ -265,6 +271,7 @@ Class CompareTransitive {A} (compare : A -> A -> comparison) : Prop :=
     compare_transitive : forall x y z comp, compare x y = comp ->
                                        compare y z = comp ->
                                        compare x z = comp.
+Hint Mode CompareTransitive ! - : typeclass_instances.
 
 (* Strict-orderedness of comparison operators *)
 Class CompareStrictOrder {A} (compare : A -> A -> comparison) : Prop :=
@@ -272,6 +279,7 @@ Class CompareStrictOrder {A} (compare : A -> A -> comparison) : Prop :=
     StrictOrder_Reflexive :> CompareReflexive compare;
     StrictOrder_Transitive :> CompareTransitive compare;
   }.
+Hint Mode CompareStrictOrder ! - : typeclass_instances.
 
 (* Strictly-ordered comparisons give decidable equality *)
 Lemma compare_eq_dec {A} `{CompareStrictOrder A} :
@@ -292,6 +300,7 @@ Definition eq_bool {X} `{CompareStrictOrder X} (x y : X) : bool :=
 (* Asymmetry of comparison operators *)
 Class CompareAsymmetric {A} (compare : A -> A -> comparison) : Prop :=
     compare_asymmetric : forall x y, compare x y = Lt <-> compare y x = Gt.
+Hint Mode CompareAsymmetric ! - : typeclass_instances.
 
 (* Strictly-ordered comparisons give asymmetry *)
 Lemma compare_asymmetric_intro {A} `{CompareStrictOrder A} :
@@ -361,7 +370,8 @@ Class StrictlyComparable (X : Type) : Type :=
      inhabited : X;
      compare : X -> X -> comparison;
      compare_strictorder :> CompareStrictOrder compare;
-    }.
+   }.
+Hint Mode StrictlyComparable ! : typeclass_instances.
 
 Instance strictly_comparable_eq_dec `{StrictlyComparable M}
   : EqDecision M.
@@ -526,7 +536,7 @@ Definition option_compare
 Lemma option_compare_reflexive
   (X : Type)
   {Xsc : StrictlyComparable X}
-  : CompareReflexive (option_compare compare).
+  : CompareReflexive (option_compare (@compare X _)).
 Proof.
   intros [x|] [y|]; simpl; split; intro H; inversion H; try reflexivity.
   - f_equal. apply StrictOrder_Reflexive in H. assumption.
@@ -536,7 +546,7 @@ Qed.
 Lemma option_compare_transitive
   (X : Type)
   {Xsc : StrictlyComparable X}
-  : CompareTransitive (option_compare compare).
+  : CompareTransitive (option_compare (@compare X _)).
 Proof.
   intros [x|] [y|] [z|] [| |]; simpl; intros Hxy Hyz; try discriminate; try reflexivity.
   - apply (StrictOrder_Transitive x y z _); assumption.
@@ -547,7 +557,7 @@ Qed.
 Lemma strictorder_option
   {X: Type}
   (Xsc : StrictlyComparable X)
-  : CompareStrictOrder (option_compare compare).
+  : CompareStrictOrder (option_compare (@compare X _)).
 Proof.
   split; exact (option_compare_reflexive X) || exact (option_compare_transitive X).
 Qed.

--- a/VLSM/FullNode/Composite/LimitedEquivocation.v
+++ b/VLSM/FullNode/Composite/LimitedEquivocation.v
@@ -400,7 +400,7 @@ Proof.
     specialize (I1 m Hm).
     apply state_union_iff in I1.
     apply state_union_iff.
-    destruct I1 as [[v' HI1] | [client' HI1]]; try destruct (decide (inr client' = inr client)).
+    destruct I1 as [[v' HI1] | [client' HI1]];[|destruct (decide ((inr client':index) = inr client))].
     + simpl. left. exists v'.  rewrite state_update_neq by (intro; discriminate).
       assumption.
     + inversion e. subst client'. right. exists client.
@@ -476,7 +476,7 @@ Proof.
             (@rev message ms))) s (@inr V clients client))
       as msgs eqn:Ht.
     apply state_union_iff in Hm.
-    destruct Hm as [[v' Hm] | [client' Hm]]; try destruct (decide (inr client' = inr client)).
+    destruct Hm as [[v' Hm] | [client' Hm]]; try destruct (decide ((inr client':index) = inr client)).
     + simpl in Hm. rewrite state_update_neq in Hm by (intro; discriminate).
       apply I2. apply state_union_iff.
       left. exists v'.


### PR DESCRIPTION
Sets mode for several classes, to prevent resolution indefinitely
applying instances like
StrictlyComparable W -> StrictlyComparable (option W)

This also required adding a few more type annotation to existing
code that used classes in very ambiguous ways, such as
 Lemma is_member_correct {W} `{StrictlyComparable W} :
  forall l w, is_member w l = true <-> In w l
With no type annotations on l and w and no explicitly-supplied
type arguments or instances on is_member, this was only
accepted because typeclass resolution instantiated the
existential variable when give a goal (StrictlyComparable _),
and StrictlyComparable W happened to be the first solution.