### PR TITLE
Make VLSM_incl,VLSM_eq take the full VLSM

### DIFF
--- a/VLSM/ByzantineTraces.v
+++ b/VLSM/ByzantineTraces.v
@@ -209,7 +209,7 @@ of <<Alt1>> into <<Preloaded>>
 *)
 
     Lemma alt_pre_loaded_with_all_messages_incl
-        : VLSM_incl (machine Alt1) (machine PreLoaded).
+        : VLSM_incl Alt1 PreLoaded.
     Proof.
         intros t Hpt.
         apply byzantine_pre_loaded_with_all_messages.
@@ -347,7 +347,7 @@ results above to show that <<Preloaded>> is included in <<Alt1>>.
 *)
 
     Lemma pre_loaded_with_all_messages_alt_incl
-        : VLSM_incl (machine PreLoaded) (machine Alt1).
+        : VLSM_incl PreLoaded Alt1.
     Proof.
         apply (basic_VLSM_incl (machine PreLoaded) (machine Alt1))
         ; intros; try (assumption || reflexivity).
@@ -364,7 +364,7 @@ results above to show that <<Preloaded>> is included in <<Alt1>>.
 Hence, <<Preloaded>> and <<Alt1>> are actually trace-equal:
 *)
     Lemma pre_loaded_with_all_messages_alt_eq
-        : VLSM_eq (machine PreLoaded) (machine Alt1)
+        : VLSM_eq PreLoaded Alt1
         .
     Proof.
         split.
@@ -451,7 +451,7 @@ We can now apply the meta-lemma [basic_VLSM_incl], using
 Lemma [pre_loaded_with_all_messages_composite_free_protocol_message] above to prove that:
 *)
     Lemma pre_loaded_with_all_messages_composite_free_incl
-        : VLSM_incl (machine PreLoadedX) (machine FreeX).
+        : VLSM_incl PreLoadedX FreeX.
     Proof.
         apply basic_VLSM_incl
         ; intros; try (assumption || reflexivity).

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -1949,27 +1949,29 @@ is also available to Y.
       {vtype : VLSM_type message}
       .
 
-    Definition VLSM_eq
+    Definition VLSM_eq_part
       {SigX SigY: VLSM_sign vtype}
       (MX : VLSM_class SigX) (MY : VLSM_class SigY)
       (X := mk_vlsm MX) (Y := mk_vlsm MY)
       :=
       forall t : Trace,
         protocol_trace_prop X t <-> protocol_trace_prop Y t .
+    Local Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
 
-    Definition VLSM_incl
+    Definition VLSM_incl_part
       {SigX SigY: VLSM_sign vtype}
       (MX : VLSM_class SigX) (MY : VLSM_class SigY)
       (X := mk_vlsm MX) (Y := mk_vlsm MY)
       :=
       forall t : Trace,
         protocol_trace_prop X t -> protocol_trace_prop Y t.
+    Local Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 
     Lemma VLSM_incl_in_futures
       {SigX SigY: VLSM_sign vtype}
       (MX : VLSM_class SigX) (MY : VLSM_class SigY)
       (X := mk_vlsm MX) (Y := mk_vlsm MY)
-      (Hincl : VLSM_incl MX MY)
+      (Hincl : VLSM_incl X Y)
       (s1 s2 : vstate X)
       (Hfuture: in_futures X s1 s2)
       : in_futures Y s1 s2.
@@ -1986,7 +1988,8 @@ is also available to Y.
     Lemma VLSM_eq_incl_l
       {SigX SigY: VLSM_sign vtype}
       (MX : VLSM_class SigX) (MY : VLSM_class SigY)
-      : VLSM_eq MX MY -> VLSM_incl MX MY.
+      (X := mk_vlsm MX) (Y := mk_vlsm MY)
+      : VLSM_eq X Y -> VLSM_incl X Y.
     Proof.
       intro Heq.
       intros t Hxt.
@@ -1997,7 +2000,8 @@ is also available to Y.
     Lemma VLSM_eq_incl_r
       {SigX SigY: VLSM_sign vtype}
       (MX : VLSM_class SigX) (MY : VLSM_class SigY)
-      : VLSM_eq MX MY -> VLSM_incl MY MX.
+      (X := mk_vlsm MX) (Y := mk_vlsm MY)
+      : VLSM_eq X Y -> VLSM_incl Y X.
     Proof.
       intro Heq.
       intros t Hyt.
@@ -2008,7 +2012,8 @@ is also available to Y.
     Lemma VLSM_eq_incl_iff
       {SigX SigY: VLSM_sign vtype}
       (MX : VLSM_class SigX) (MY : VLSM_class SigY)
-      : VLSM_eq MX MY <-> VLSM_incl MX MY /\ VLSM_incl MY MX.
+      (X := mk_vlsm MX) (Y := mk_vlsm MY)
+      : VLSM_eq X Y <-> VLSM_incl X Y /\ VLSM_incl Y X.
     Proof.
       split.
       - intro Heq.
@@ -2023,6 +2028,9 @@ is also available to Y.
     Qed.
   (* end hide *)
   End VLSM_equality.
+
+Notation VLSM_eq X Y := (VLSM_eq_part (machine X) (machine Y)).
+Notation VLSM_incl X Y := (VLSM_incl_part (machine X) (machine Y)).
 
 (** It is natural to look for sufficient conditions for VLSM inclusion (or equality),
 which are easy to verify in a practical setting. One such result is the following.
@@ -2153,7 +2161,7 @@ Qed.
   (* end hide *)
 
   Lemma basic_VLSM_incl
-    : VLSM_incl MX MY.
+    : VLSM_incl X Y.
   Proof.
     intros [s ls| s ss]; simpl; intros [Hxt Hinit].
     - apply VLSM_incl_finite_ptrace in Hxt.
@@ -2266,7 +2274,7 @@ Byzantine fault tolerance analysis. *)
   (* end hide *)
 
   Lemma vlsm_incl_pre_loaded_with_all_messages_vlsm
-    : VLSM_incl (machine X) pre_loaded_with_all_messages_vlsm_machine.
+    : VLSM_incl X pre_loaded_with_all_messages_vlsm.
   Proof.
     apply (basic_VLSM_incl (machine X) pre_loaded_with_all_messages_vlsm_machine)
     ; intros; try (assumption || reflexivity)

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -465,7 +465,7 @@ Then <<X1>> is trace-included into <<X2>>.
 *)
 
     Lemma constraint_subsumption_incl
-      : VLSM_incl (machine X1) (machine X2).
+      : VLSM_incl X1 X2.
     Proof.
       apply (basic_VLSM_incl (machine X1) (machine X2))
       ; intros; try (assumption || reflexivity).
@@ -477,7 +477,7 @@ Then <<X1>> is trace-included into <<X2>>.
     Qed.
 
     Lemma constraint_subsumption_pre_loaded_with_all_messages_incl
-      : VLSM_incl (machine (pre_loaded_with_all_messages_vlsm X1)) (machine (pre_loaded_with_all_messages_vlsm X2)).
+      : VLSM_incl (pre_loaded_with_all_messages_vlsm X1) (pre_loaded_with_all_messages_vlsm X2).
     Proof.
       apply (basic_VLSM_incl (machine (pre_loaded_with_all_messages_vlsm X1)) (machine (pre_loaded_with_all_messages_vlsm X2)))
       ; intros; try (assumption || reflexivity).
@@ -513,7 +513,7 @@ Thus, the [free_composite_vlsm] is the [composite_vlsm] using the
 
     Lemma constraint_free_incl
       (constraint : composite_label -> composite_state  * option message -> Prop)
-      : VLSM_incl (machine (composite_vlsm constraint)) (machine free_composite_vlsm).
+      : VLSM_incl (composite_vlsm constraint) free_composite_vlsm.
     Proof.
       apply constraint_subsumption_incl.
       intro l; intros. exact I.
@@ -839,7 +839,7 @@ We can now finally prove the main result for this section:
 *)
     Lemma proj_pre_loaded_with_all_messages_incl
       (PreLoaded := pre_loaded_with_all_messages_vlsm (IM j))
-      : VLSM_incl (machine Xj) (machine PreLoaded).
+      : VLSM_incl Xj PreLoaded.
     Proof.
       apply (basic_VLSM_incl (machine Xj) (machine PreLoaded))
       ; intros; try (assumption || reflexivity).
@@ -1255,4 +1255,3 @@ This instantiates the regular composition using the [bool] type as an <<index>>.
     := composite_vlsm_free_projection binary_IM first second.
 
 End binary_free_composition.
-

--- a/VLSM/Validating.v
+++ b/VLSM/Validating.v
@@ -141,7 +141,7 @@ Lemma [protocol_message_projection] to show that its conditions are fulfilled.
 *)
 
     Lemma pre_loaded_with_all_messages_validating_proj_incl
-        : VLSM_incl (machine PreLoaded) (machine Xi).
+        : VLSM_incl PreLoaded Xi.
     Proof.
         apply (basic_VLSM_incl (machine PreLoaded) (machine Xi))
         ; intros; try destruct H as [_ [_ H]]; try (assumption || reflexivity).
@@ -157,7 +157,7 @@ trace-equal.  This means that all the byzantine behavior of a
 validating component is exhibited by its corresponding projection.
 *)
     Lemma pre_loaded_with_all_messages_validating_proj_eq
-        : VLSM_eq (machine PreLoaded) (machine Xi).
+        : VLSM_eq PreLoaded Xi.
     Proof.
         split.
         - apply pre_loaded_with_all_messages_validating_proj_incl.
@@ -215,7 +215,7 @@ verify the conditions of meta-lemma [basic_VLSM_incl].
 *)
 
     Lemma pre_loaded_with_all_messages_validating_vlsm_incl
-        : VLSM_incl (machine PreLoaded) (machine X).
+        : VLSM_incl PreLoaded X.
     Proof.
         apply (basic_VLSM_incl (machine PreLoaded) (machine X))
         ; intros; try destruct H as [_ [_ H]]; try (assumption || reflexivity).
@@ -230,7 +230,7 @@ We conclude that <<X>> and <<Preloaded>> are trace-equal.
 *)
 
     Lemma pre_loaded_with_all_messages_validating_vlsm_eq
-        : VLSM_eq (machine PreLoaded) (machine X).
+        : VLSM_eq PreLoaded X.
     Proof.
         split.
         - apply pre_loaded_with_all_messages_validating_vlsm_incl.


### PR DESCRIPTION
This renames the existing defintions and makes
VLSM_incl and VLSM_eq into notations that apply
the old definitions to the parts of the full VLSM,
letting the claims be written like `VLSM_eq X1 X2`
instead of `VLSM_eq (machine X1) (machine X2)`.