### PR TITLE
Make setting changes in SsrExport non-transitive

### DIFF
--- a/Lib/SsrExport.v
+++ b/Lib/SsrExport.v
@@ -1,4 +1,4 @@
 From Coq Require Export ssreflect.
-Global Set SsrOldRewriteGoalsOrder.
-Global Set Asymmetric Patterns.
-Global Set Bullet Behavior "None".
+Export Set SsrOldRewriteGoalsOrder.
+Export Set Asymmetric Patterns.
+Export Set Bullet Behavior "None".


### PR DESCRIPTION
Changes the Global Set command to Export Set.
The settings in SsrExport has been affecting not just
files that directly import it, but also any other file
importing those files.
Among other changes, this disabled enforcing the bullet
structure of proof.