### PR TITLE
Observable Equivocation from lv_common_futures branch.

### DIFF
--- a/VLSM/FullNode/Client.v
+++ b/VLSM/FullNode/Client.v
@@ -47,12 +47,18 @@ messages, implementing a limited equivocation tolerance policy.
     :=
     filter (fun m => if decide (sender m = v) then true else false) s.
 
-  Definition full_node_client_observation_based_equivocation_evidence
-    : observation_based_equivocation_evidence (set message) V message decide_eq _ happens_before_dec
+  Program Definition full_node_client_observation_based_equivocation_evidence
+    : observation_based_equivocation_evidence (set message) V message decide_eq _ happens_before_dec sender
     :=
     {|
       observable_events := full_node_client_observable_events
     |}.
+  Next Obligation.
+    unfold full_node_client_observable_events in He.
+    apply filter_In in He.
+    destruct He as [_ He].
+    destruct (decide (sender e = v)); solve [intuition;discriminate He].
+  Qed.
 
   Existing Instance full_node_client_observation_based_equivocation_evidence.
 
@@ -72,7 +78,7 @@ messages, implementing a limited equivocation tolerance policy.
   Definition client_basic_equivocation
     : basic_equivocation (set message) V
     := basic_observable_equivocation (set message) V message
-        _ full_node_client_state_validators full_node_client_state_validators_nodup.
+        _ happens_before full_node_client_state_validators full_node_client_state_validators_nodup.
 
   Existing Instance client_basic_equivocation.
 

--- a/VLSM/FullNode/Validator.v
+++ b/VLSM/FullNode/Validator.v
@@ -40,12 +40,19 @@ Section CompositeValidator.
     :=
     full_node_client_observable_events (get_message_set s) v.
 
-  Definition full_node_validator_observation_based_equivocation_evidence
-    : observation_based_equivocation_evidence (state C V) V message decide_eq _ message_preceeds_dec
+  Program Definition full_node_validator_observation_based_equivocation_evidence
+    : observation_based_equivocation_evidence (state C V) V message decide_eq _ message_preceeds_dec sender
     :=
     {|
       observable_events := full_node_validator_observable_events
     |}.
+  Next Obligation.
+  unfold full_node_validator_observable_events in He.
+  unfold full_node_client_observable_events in He.
+  apply filter_In in He.
+  destruct He as [_ He].
+  destruct (decide (sender e = v)); solve [intuition; discriminate He].
+  Qed.
 
   Existing Instance full_node_validator_observation_based_equivocation_evidence.
 
@@ -65,7 +72,7 @@ Section CompositeValidator.
   Definition validator_basic_equivocation
     : basic_equivocation (state C V) V
     := basic_observable_equivocation (state C V) V message _
-        full_node_validator_state_validators full_node_validator_state_validators_nodup.
+        _ full_node_validator_state_validators full_node_validator_state_validators_nodup.
 
   (** * Full-node validator VLSM instance
 

--- a/VLSM/ListValidator/Equivocation.v
+++ b/VLSM/ListValidator/Equivocation.v
@@ -3642,43 +3642,4 @@ Context
         rewrite Hproj_ui.
         assumption.
     Qed.
-
-    Definition observable_full :
-      (observation_based_equivocation_evidence
-       (@state index index_listing)
-       index
-       (@state index index_listing)
-       state_eq_dec state_lt state_lt_dec) := {|
-       observable_events := full_observations;
-      |}.
-
-   Existing Instance observable_full.
-
-   Definition get_validators {State : Type} (s : State) : list index := index_listing.
-
-   Lemma get_validators_nodup
-    {State : Type}
-    (s : State) :
-    NoDup (get_validators s).
-   Proof.
-    unfold get_validators.
-    apply Hfinite.
-   Qed.
-
-   Definition lv_basic_equivocation : basic_equivocation state index :=
-      @basic_observable_equivocation
-      (@state index index_listing)
-      index
-      (@state index index_listing)
-      state_eq_dec
-      state_lt
-      state_lt_dec
-      observable_full
-      Mindex
-      Rindex
-      get_validators
-      get_validators_nodup.
-
-   Existing Instance lv_basic_equivocation.
-
 End Equivocation.

--- a/VLSM/ListValidator/EquivocationAwareListValidator.v
+++ b/VLSM/ListValidator/EquivocationAwareListValidator.v
@@ -11,7 +11,7 @@ Require Import
   VLSM.ListValidator.ListValidator
   VLSM.ListValidator.Equivocation
   .
-
+(* 
 Section EquivocationAwareValidator.
 
   Context
@@ -61,4 +61,4 @@ Section EquivocationAwareValidator.
     :=
     @VLSM_list index index_self index_listing idec equivocation_aware_estimator.
 
-End EquivocationAwareValidator.
+End EquivocationAwareValidator. *)

--- a/VLSM/ListValidator/GeneralComposition.v
+++ b/VLSM/ListValidator/GeneralComposition.v
@@ -32,10 +32,11 @@ Context
   {constraint : composite_label IM_index -> (composite_state IM_index) * option message -> Prop}
   (X := composite_vlsm IM_index i0 constraint)
   (preX := pre_loaded_with_all_messages_vlsm X)
-  (Hevidence := fun (i : index) => @observable_full index index_listing Hfinite idec)
+  (* (Hevidence := fun (i : index) => @observable_full index index_listing Hfinite idec) *)
   {Mindex : Measurable index}
   {Rindex : ReachableThreshold index}
   .
+ (*
 
   Definition composed_eqv_evidence
   : observation_based_equivocation_evidence (vstate X) index state state_eq_dec state_lt state_lt_dec
@@ -466,5 +467,5 @@ Context
     {
       comparable_generated_events := comparable_generated_events_lv
     }.
-
+ *)
 End Composition.

--- a/VLSM/PreceedsEquivocation.v
+++ b/VLSM/PreceedsEquivocation.v
@@ -351,10 +351,18 @@ Proof.
   reflexivity.
 Qed.
 
-Definition message_observation_based_equivocation_evidence
-  : @observation_based_equivocation_evidence state validator message _ _ message_preceeds_dec
+Program Definition message_observation_based_equivocation_evidence
+  : @observation_based_equivocation_evidence state validator message _ _ message_preceeds_dec sender
   :=
   {| observable_events := observable_messages |}.
+Next Obligation.
+  unfold observable_messages in He.
+  apply filter_In in He.
+  destruct He as [_ He].
+  destruct (decide (sender e = v)).
+  - assumption.
+  - discriminate He.
+Qed.
 
 (**
 Further, we can get all validators for a state by projecting the messages
@@ -367,7 +375,7 @@ Definition message_basic_observable_equivocation
   (validators := fun s => set_map decide_eq sender (get_messages s))
   (validators_nodup := fun s => set_map_nodup sender (get_messages s))
   : basic_equivocation state validator
-  := @basic_observable_equivocation state validator message _ _ _ Hevidence _ _ validators validators_nodup.
+  := @basic_observable_equivocation state validator message _ _ _ message_preceeds_dec Hevidence _ _ validators validators_nodup.
 
 (**
 We can now show that the [message_based_equivocation] (customly built for


### PR DESCRIPTION
- This PR extracts files pertaining to the observable equivocation framework from the `lv_common_futures` branch. @traiansf is working on updating the observable equivocation framework and needs to merge his changes with the ones presented here.
- Because these changes would break some other files in `master`, said files have been altered (mostly commented out) temporarily. They will be restored by their correspondents in `lv_common_futures` in future PRs. 