### PR TITLE
Define lemmas reducing has_been_sent_prop to a stepwise condition

### DIFF
--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -1405,6 +1405,37 @@ in <<s>> by outputting <<m>> *)
         intros Hlf; apply Hlf. intros HC; inversion HC.
     Qed.
 
+    (** Giving a trace for [protocol_state_prop] can be stated more
+        simply than [protocol_is_trace], because we don't need a
+        disjunction because we are not making claims about [output]
+        messages.
+     *)
+    Lemma protocol_state_has_trace
+          (s : state)
+          (Hp : protocol_state_prop s):
+      exists (is : state) (tr : list transition_item),
+        finite_protocol_trace is tr /\
+        last (List.map destination tr) is = s.
+    Proof using.
+      destruct Hp as [_om Hp].
+      apply protocol_is_trace in Hp.
+      destruct Hp as [Hinit|Htrace].
+      + exists s, [].
+        split;[|reflexivity].
+        split;[|assumption].
+        apply finite_ptrace_empty.
+        apply initial_is_protocol.
+        assumption.
+      + destruct Htrace as [is [tr [Htr [Hlast _]]]].
+        exists is, tr.
+        split;[assumption|].
+        clear -Hlast.
+        destruct tr;[discriminate Hlast|].
+        rewrite last_map.
+        injection Hlast.
+        trivial.
+    Qed.
+
     (** Any trace with the 'finite_protocol_trace_from' property can be completed
     (to the left) to start in an initial state*)
     Lemma finite_protocol_trace_from_complete_left


### PR DESCRIPTION
These lemmas reduce proving the `proper_sent` and `proper_not_sent` conditions to proving one condition on how the `has_been_sent` predicate changes across a single transition, and one that `initial_states` don't claim to have sent anything.
This is extracted from my code for liveness.

I stated the condition just in terms of `transition` because I didn't need the validity condition, but I suspect that using `protocol_transition` would make this condition be also implied by `proper_sent` plus `proper_not_sent`, and thus fully equivalent to the existing definition.

The proofs could be further generalized to cover `has_been_received`, or other similar predicates.