### PR TITLE
Make protocol_state_prop_ind usable with "induction using"

### DIFF
--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -614,6 +614,15 @@ and [protocol_message]s, similar to their recursive definition.
         + exists om'. rewrite <- Ht. apply protocol_generated with _om _s; assumption.
     Qed.
 
+    (** A specialized induction principle for [protocol_state_prop].
+
+        Compared to opening the existential and using [protocol_prop_ind],
+        this avoids the redundancy of the [protocol_initial_state] case
+        needing a proof for any [initial_state] and then [protocol_initial_message]
+        asking for a proof specifically for [s0], and also avoids the
+        little trouble of needing <<set>> or <<dependent induction>> to
+        handle the pair in the index in [protocol_prop (s,om)].
+     *)
     Lemma protocol_state_prop_ind
       (P : state -> Prop)
       (IHinit : forall (s : state) (Hs : initial_state_prop s), P s)
@@ -2009,6 +2018,12 @@ that contains it as a prefix.
       }.
 (* end hide *)
   End VLSM.
+
+(** Make all arguments of [protocol_state_prop_ind] explicit
+    so it will work with the <<induction using>> tactic.
+    (closing the section added <<{message}>> as an implicit argument)
+ *)
+Arguments protocol_state_prop_ind : clear implicits.
 
 (**
 ** VLSM Inclusion and Equality.

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -1177,12 +1177,7 @@ All results from regular projections carry to these "free" projections.
     : protocol_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i).
   Proof.
     revert i. generalize dependent s.
-    apply
-      (protocol_state_prop_ind (pre_loaded_with_all_messages_vlsm X)
-        (fun (s : vstate (pre_loaded_with_all_messages_vlsm X)) =>
-          forall i : index, protocol_state_prop (pre_loaded_with_all_messages_vlsm (IM i)) (s i)
-        )
-      ); intros.
+    induction 1 using protocol_state_prop_ind; intros.
     - apply protocol_state_prop_iff. left. specialize (Hs i). unfold vinitial_state_prop in Hs.
       exists (exist _ (s i) Hs). reflexivity.
     - destruct Ht as [[Hps [Hpm [Hv _]]] Ht].
@@ -1193,7 +1188,7 @@ All results from regular projections carry to these "free" projections.
       inversion Ht. subst s' omi'; clear Ht.
       destruct (decide (i = i')).
       + subst i'. rewrite state_update_eq.
-        specialize (Hs i).
+        specialize (IHHs i).
         apply protocol_state_prop_iff. right.
         exists li'. exists (s i, om). exists om'.
         repeat split; try assumption.
@@ -1204,7 +1199,7 @@ All results from regular projections carry to these "free" projections.
           pose (exist _ m Him) as im.
           apply (protocol_initial_message (pre_loaded_with_all_messages_vlsm (IM i)) im).
         * apply (protocol_initial_state (pre_loaded_with_all_messages_vlsm (IM i))).
-      + rewrite state_update_neq; try assumption. apply Hs.
+      + rewrite state_update_neq; try assumption. apply IHHs.
   Qed.
 
   Lemma pre_loaded_with_all_messages_projection_protocol_transition_eq

--- a/VLSM/Equivocators/Common.v
+++ b/VLSM/Equivocators/Common.v
@@ -431,11 +431,8 @@ Lemma preloaded_equivocator_state_project_protocol_state
   :
   protocol_state_prop (pre_loaded_with_all_messages_vlsm X) (projT2 bs i).
 Proof.
-  revert i.
-  pose (fun bs : vstate equivocator_vlsm => forall i : t (S (projT1 bs)), protocol_state_prop (pre_loaded_with_all_messages_vlsm X) (projT2 bs i)) as P.
-  revert Hbs. revert bs.
-  apply (protocol_state_prop_ind (pre_loaded_with_all_messages_vlsm equivocator_vlsm) P)
-  ; unfold P in *; clear P; intros.
+  revert bs Hbs i.
+  induction 1 using protocol_state_prop_ind;intros.
   - destruct Hs as [Hzero His].
     destruct s. simpl in *. subst x. exists None.
     dependent destruction i; [|inversion i].
@@ -451,14 +448,14 @@ Proof.
       unfold equivocator_state_extend.
       destruct s as (ns, bs).
       simpl in *. destruct (to_nat i) as (ni, Hni).
-      destruct (nat_eq_dec ni (S ns)); [|apply Hs].
+      destruct (nat_eq_dec ni (S ns)); [|apply IHHbs].
       subst. exists None.
       change sn with (proj1_sig (exist _ sn Hsn)).
       constructor.
     + destruct Hv as [Hj Hv].
       destruct (le_lt_dec (S (projT1 s)) j); [lia|].
       replace (of_nat_lt l0) with (of_nat_lt Hj) in * by apply of_nat_ext. clear l0.
-      destruct (Hs (of_nat_lt Hj)) as [_omj Hsj].
+      destruct (IHHbs (of_nat_lt Hj)) as [_omj Hsj].
       specialize (protocol_generated (pre_loaded_with_all_messages_vlsm X) l (projT2 s (of_nat_lt Hj)) _omj Hsj)
         as Hgen.
       spec Hgen (proj1_sig (vs0 X)) om (pre_loaded_with_all_messages_message_protocol_prop X om) Hv.
@@ -470,9 +467,9 @@ Proof.
       destruct is_equiv as [|]; inversion Ht; subst; clear Ht; simpl in *.
       * destruct s as (ns, bs). simpl in *.
         destruct (to_nat i) as (ni, Hni).
-        destruct (nat_eq_dec ni (S ns)); [|apply Hs].
+        destruct (nat_eq_dec ni (S ns)); [|apply IHHbs].
         exists om'. assumption.
-      * destruct (Fin.eq_dec (of_nat_lt Hj) i); [|apply Hs].
+      * destruct (Fin.eq_dec (of_nat_lt Hj) i); [|apply IHHbs].
         exists om'. assumption.
 Qed.
 

--- a/VLSM/FullNode/Client.v
+++ b/VLSM/FullNode/Client.v
@@ -151,13 +151,7 @@ messages, implementing a limited equivocation tolerance policy.
     (Hs : protocol_state_prop bvlsm s)
     : NoDup s.
   Proof.
-    generalize dependent s.
-    apply
-      (protocol_state_prop_ind (pre_loaded_with_all_messages_vlsm VLSM_full_client2)
-        (fun (s : vstate (pre_loaded_with_all_messages_vlsm VLSM_full_client2)) =>
-          NoDup s
-        )
-      ); intros.
+    induction Hs using protocol_state_prop_ind.
     - inversion Hs. constructor.
     - destruct Ht as [_ Ht].
       simpl in Ht. unfold vtransition in Ht. simpl in Ht.
@@ -210,29 +204,21 @@ messages, implementing a limited equivocation tolerance policy.
     (Hm : In m s)
     : incl (unmake_message_set (justification_message_set (get_justification m))) s.
   Proof.
-    generalize dependent m. generalize dependent s.
-    pose
-      (fun (s : set message) =>
-        forall (m : message) (Hm : In m s),
-          incl
-            (unmake_message_set (justification_message_set (get_justification m)))
-            s
-      ) as P.
-    apply (protocol_state_prop_ind bvlsm P); unfold P; intros.
+    induction Hs using protocol_state_prop_ind.
     - inversion Hs. subst s. inversion Hm.
     - destruct Ht as [[Hps [Hom Hv]] Ht].
       simpl in Ht. unfold vtransition in Ht. simpl in Ht.
       simpl in Hv. unfold vvalid in Hv. simpl in Hv.
       destruct om as [msg|]; inversion Ht; subst; clear Ht
-      ; simpl in Hs; simpl in Hv; simpl
-      ; try (apply Hs; assumption).
+      ; simpl in IHHs; simpl in Hv; simpl;
+        [|apply IHHs;assumption].
       destruct Hv as [Hnmsg [Hv Hnh]].
       apply set_add_iff in Hm.
       destruct Hm as [Heqm | Hm].
       + subst m.
         apply incl_tran with s; try assumption.
         intros x Hx; apply set_add_iff. right. assumption.
-      + specialize (Hs m Hm).
+      + specialize (IHHs Hm).
         apply incl_tran with s; try assumption.
         intros x Hx; apply set_add_iff. right. assumption.
   Qed.

--- a/VLSM/ListValidator/Equivocation.v
+++ b/VLSM/ListValidator/Equivocation.v
@@ -1154,51 +1154,46 @@ Context
       (Hnb : last_sent s <> Bottom)
       : state_lt (last_sent s) s.
     Proof.
-      generalize dependent s.
-      remember (fun s => last_sent s <> Bottom -> state_lt (last_sent s) s) as P.
-      specialize (protocol_state_prop_ind (pre_loaded_with_all_messages_vlsm X) P) as Hind.
-      subst P.
-      apply Hind; intros; clear Hind.
-      - inversion Hs. subst s. elim H.
+      induction Hs using protocol_state_prop_ind.
+      - inversion Hs. subst s. elim Hnb.
         unfold last_sent. simpl. apply project_all_bottom.
       - unfold last_sent.
         destruct Ht as [[Hps [Hom Hv]] Ht].
-        specialize (protocol_prop_no_bottom _ Hps) as Hnb.
+        specialize (protocol_prop_no_bottom _ Hps) as Hnb'.
         simpl in Ht. unfold vtransition in Ht. simpl in Ht.
         simpl in Hv. unfold vvalid in Hv. simpl in Hv.
         destruct l as [c|].
         + inversion Ht. clear Ht.
           subst s'.
           rewrite <- update_consensus_clean.
-          rewrite (@project_same _ _ Hfinite); try assumption.
-          repeat split
-          ; try (intro j; rewrite history_disregards_cv; destruct (decide (index_self = j))).
-          * subst j. rewrite history_append; try assumption; try reflexivity.
+          rewrite (@project_same _ _ Hfinite);[|assumption].
+          split;[(intro j; rewrite history_disregards_cv; destruct (decide (index_self = j)))|].
+          * subst j. rewrite history_append;[|assumption|assumption|reflexivity].
             apply incl_tl. apply incl_refl.
-          * rewrite <- history_oblivious; try assumption. apply incl_refl.
+          * rewrite <- history_oblivious;[|assumption]. apply incl_refl.
           * exists index_self. exists s.
-            split; try apply history_no_self_reference.
+            split;[|solve[apply history_no_self_reference]].
             rewrite history_disregards_cv.
-            rewrite history_append; try assumption; try reflexivity.
+            rewrite history_append;[|assumption|assumption|reflexivity].
             left. reflexivity.
         + destruct om as [m|]; inversion Ht; clear Ht; subst s'.
           * destruct m as (im, sm); simpl in *.
             destruct Hv as [Hsim [Hsm Him]].
-            rewrite (@project_different _ _ Hfinite); try assumption.
-            unfold last_sent in H.
-            rewrite (@project_different _ _ Hfinite) in H; try assumption.
-            { repeat split; try (intro j; destruct (decide (im = j))).
+            rewrite (@project_different _ _ Hfinite) by assumption.
+            unfold last_sent in Hnb.
+            rewrite (@project_different _ _ Hfinite) in Hnb by assumption.
+            { split;[intro j; destruct (decide (im = j))|].
             - subst im. rewrite history_append; auto.
-              apply incl_tl. apply Hs. assumption.
-            - rewrite <- history_oblivious; try assumption.
-              apply Hs. assumption.
+              apply incl_tl. apply IHHs. assumption.
+            - rewrite <- history_oblivious by assumption.
+              apply IHHs. assumption.
             - exists index_self. exists (project s index_self).
-              split; try apply history_no_self_reference.
+              split;[|solve[apply history_no_self_reference]].
               rewrite <- history_oblivious.
-              + rewrite unfold_history_cons; try assumption. left. reflexivity.
+              + rewrite unfold_history_cons;[|assumption]. left. reflexivity.
               + intro. subst. elim Him. reflexivity.
             }
-          * apply Hs. assumption.
+          * apply IHHs. assumption.
     Qed.
 
     Lemma byzantine_message_self_id


### PR DESCRIPTION
The implicit parameter {message} added from the section
was making this lemma unusable with the "induction using" tactic.
This tactic automatically finds the predicate P to use for the
induction, and also generalizes over other hypotheses that mention
the state for which we have protocol_state_prop.

This commit fixes the arguments of protocol_state_prop_ind, and changes
every place that was manually applying the lemma to instead
use "induction _ using protocol_state_prop_ind".

(This came up when I was looking for an induction principle to prove some invariants for liveness)