### PR TITLE
remove UTF8 character from ListValidator.v

### DIFF
--- a/VLSM/ListValidator/ListValidator.v
+++ b/VLSM/ListValidator/ListValidator.v
@@ -13,7 +13,7 @@ Section ListNode.
 We introduce here the "minimal list validator protocol", by quoting the official
 documentation:
 
-In this section, we propose a protocol where each validator keeps a list of states of other validators. Each validator broadcasts its view of the other validators’
+In this section, we propose a protocol where each validator keeps a list of states of other validators. Each validator broadcasts its view of the other validators'
 states. We claim that the protocol is nontrivial and safe: when equivocations are limited, it is possible to reach either outcome, and if the protocol reaches
 a decision, all the validators agree on what it is.
 


### PR DESCRIPTION
We had a single UTF8 character in a file, and I think this is what is breaking Alectryon proof movie generation. This seems very fragile, so I will also report the (Python) issue upstream, which looks like this:
```
'ascii' codec can't encode character '\u2191' in position 6443: ordinal not in range(128)
```
Basically, our CI has not set the UTF8 character set as default in the shell environment, so Alectryon seemingly does not accept any UTF8 without choking.