### PR TITLE
disable alectryon in Jenkins CI for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,10 @@ pipeline {
         sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
           sh '''
             eval $(opam env)
-            make -j 6 coqdoc coq2html alectryon
+            make -j 6
+            make coqdoc
+            make coq2html
+            #make -j 6 alectryon
             export COQ_SHA=$(git rev-parse HEAD)
 
             git clone 'ssh://github.com/runtimeverification/casper-cbc-proof-docs.git'
@@ -47,7 +50,7 @@ pipeline {
             cd docs
             cp -r ../../docs/coqdoc ${COQ_SHA}
             cp -r ../../docs/coq2html ${COQ_SHA}
-            cp -r ../../docs/alectryon ${COQ_SHA}
+            #cp -r ../../docs/alectryon ${COQ_SHA}
             ln -sfn ${COQ_SHA} latest
             cd ..
 


### PR DESCRIPTION
Until the encoding issues in CI have been reproduced locally and figured out, I'm disabling alectryon in Jenkins CI so we can have a green build again.