### PR TITLE
Has been sent equivalence

### DIFF
--- a/VLSM/Equivocation.v
+++ b/VLSM/Equivocation.v
@@ -980,21 +980,9 @@ Section Composite.
   Lemma composite_has_been_sent_dec : RelDecision composite_has_been_sent.
   Proof.
     intros s m.
-    destruct (existsb (fun i => bool_decide(has_been_sent (IM i) (s i) m)) index_listing)
-      eqn:Hexists.
-    - left.
-      apply existsb_exists in Hexists.
-      destruct Hexists as [i [_ Hi]].
-      exists i.
-      apply bool_decide_eq_true_1 in Hi.
-      assumption.
-    - right.
-      rewrite existsb_forall in Hexists.
-      intros Hbs.
-      destruct Hbs as [i Hbs].
-      spec Hexists i (proj2 finite_index i).
-      apply bool_decide_eq_false_1 in Hexists.
-      elim Hexists. assumption.
+    apply (Decision_iff (P:=List.Exists (fun i => has_been_sent (IM i) (s i) m) index_listing)).
+    rewrite <- exists_finite by (apply finite_index). reflexivity.
+    apply Exists_dec.
   Qed.
 
   (** 'composite_has_been_sent' has the 'proper_sent' property. *)

--- a/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -1021,7 +1021,7 @@ Proof.
   specialize (Heqv eq_refl).
   apply
     (specialized_selected_message_exists_in_some_traces_from (free_composite_vlsm equivocator_IM i0)
-      output
+      (field_selector output)
     ) with full_replay_state (replay_trace_from full_replay_state is epref)
   ; [assumption|reflexivity|].
   apply Exists_exists in Heqv.

--- a/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -610,7 +610,7 @@ Proof.
           }
           specialize
             (specialized_selected_message_exists_in_some_traces_from
-              (free_composite_vlsm equivocator_IM i0) output _ m _ _ Happ_free eq_refl
+              (free_composite_vlsm equivocator_IM i0) (field_selector output) _ m _ _ Happ_free eq_refl
             ) as Hspec.
           rewrite map_app in Hspec.
           rewrite last_app in Hspec. simpl in Hspec.
@@ -618,7 +618,7 @@ Proof.
           rewrite <- Heqv_state_final. subst.
           rewrite <- Heqv_state_final in Hspec.
           apply Hspec.
-          
+
           apply Exists_app. right.
           spec Houtput n.
           clear - Hfinal Houtput Hom n.

--- a/VLSM/Equivocators/MessageProperties.v
+++ b/VLSM/Equivocators/MessageProperties.v
@@ -327,7 +327,7 @@ Proof.
       rewrite Hlast in Hpbs.
       apply (preloaded_equivocator_state_project_protocol_state _ _ Hpbs).
     }
-    assert (Hall : selected_message_exists_in_all_traces X output (projT2 s (of_nat_lt Hj)) m).
+    assert (Hall : selected_message_exists_in_all_preloaded_traces X output (projT2 s (of_nat_lt Hj)) m).
     { apply has_been_sent_consistency; [assumption|assumption|].
       destruct i as [sn | i fi].
       - destruct Hi as [Hlastx HtrX].
@@ -532,7 +532,7 @@ Proof.
     + specialize (last_error_destination_last _ _ Hlast is) as Hlst. clear Hlast.
       assert (Hinv := of_nat_to_nat_inv i).
       destruct (to_nat i) as [ni Hi]. simpl in Hinv. subst i.
-      assert (Hbm : selected_message_exists_in_some_traces equivocator_vlsm output s m)
+      assert (Hbm : selected_message_exists_in_some_preloaded_traces equivocator_vlsm output s m)
       ; [|exists (exist _ m Hbm); reflexivity].
       exists is. exists tr. exists Htr. exists Hlst.
       subst s.
@@ -573,7 +573,7 @@ Proof.
     + apply in_map_iff. exists (of_nat_lt Hi).
       split; [reflexivity|]. apply fin_t_full.
     + apply (sent_messages_full X); [apply HpsX|].
-      assert (Hm : selected_message_exists_in_some_traces X output (projT2 s (of_nat_lt Hi)) m)
+      assert (Hm : selected_message_exists_in_some_preloaded_traces X output (projT2 s (of_nat_lt Hi)) m)
       ; [|exists (exist _ m Hm); reflexivity].
       destruct istart as [sstart | istart fstart].
       * destruct Histart as [Hlast HtrX].

--- a/VLSM/Equivocators/MessageProperties.v
+++ b/VLSM/Equivocators/MessageProperties.v
@@ -303,7 +303,7 @@ Lemma equivocator_has_been_sent_consistency
   (s : vstate equivocator_vlsm)
   (Hs : protocol_state_prop (pre_loaded_with_all_messages_vlsm equivocator_vlsm) s)
   (m : message)
-  : selected_messages_consistency_prop equivocator_vlsm output s m.
+  : selected_messages_consistency_prop equivocator_vlsm (field_selector output) s m.
 Proof.
   split.
   - intros [bis [btr [Hbtr [Hlast Hsome]]]].
@@ -327,7 +327,7 @@ Proof.
       rewrite Hlast in Hpbs.
       apply (preloaded_equivocator_state_project_protocol_state _ _ Hpbs).
     }
-    assert (Hall : selected_message_exists_in_all_preloaded_traces X output (projT2 s (of_nat_lt Hj)) m).
+    assert (Hall : selected_message_exists_in_all_preloaded_traces X (field_selector output) (projT2 s (of_nat_lt Hj)) m).
     { apply has_been_sent_consistency; [assumption|assumption|].
       destruct i as [sn | i fi].
       - destruct Hi as [Hlastx HtrX].
@@ -357,7 +357,7 @@ Proof.
     destruct Hs as [om Hs].
     apply (protocol_is_trace (pre_loaded_with_all_messages_vlsm equivocator_vlsm)) in Hs.
     destruct Hs as [Hinit | [is [tr [Htr [Hlast _]]]]]
-    ; [elim (selected_message_exists_in_all_traces_initial_state equivocator_vlsm s Hinit output m)
+    ; [elim (selected_message_exists_in_all_traces_initial_state equivocator_vlsm s Hinit (field_selector output) m)
       ; assumption|].
     exists is. exists tr. exists Htr.
     assert (Hlst := last_error_destination_last _ _ Hlast is).
@@ -405,7 +405,7 @@ Proof.
     destruct Hs as [om Hs].
     apply (protocol_is_trace (pre_loaded_with_all_messages_vlsm equivocator_vlsm)) in Hs.
     destruct Hs as [Hinit | [is [tr [Htr [Hlast _]]]]]
-    ; [elim (selected_message_exists_in_all_traces_initial_state equivocator_vlsm s Hinit output m)
+    ; [elim (selected_message_exists_in_all_traces_initial_state equivocator_vlsm s Hinit (field_selector output) m)
       ; assumption|].
     assert (Hlst := last_error_destination_last _ _ Hlast is).
     spec Hbbs is tr Htr Hlst.
@@ -532,7 +532,7 @@ Proof.
     + specialize (last_error_destination_last _ _ Hlast is) as Hlst. clear Hlast.
       assert (Hinv := of_nat_to_nat_inv i).
       destruct (to_nat i) as [ni Hi]. simpl in Hinv. subst i.
-      assert (Hbm : selected_message_exists_in_some_preloaded_traces equivocator_vlsm output s m)
+      assert (Hbm : selected_message_exists_in_some_preloaded_traces equivocator_vlsm (field_selector output) s m)
       ; [|exists (exist _ m Hbm); reflexivity].
       exists is. exists tr. exists Htr. exists Hlst.
       subst s.
@@ -573,7 +573,7 @@ Proof.
     + apply in_map_iff. exists (of_nat_lt Hi).
       split; [reflexivity|]. apply fin_t_full.
     + apply (sent_messages_full X); [apply HpsX|].
-      assert (Hm : selected_message_exists_in_some_preloaded_traces X output (projT2 s (of_nat_lt Hi)) m)
+      assert (Hm : selected_message_exists_in_some_preloaded_traces X (field_selector output) (projT2 s (of_nat_lt Hi)) m)
       ; [|exists (exist _ m Hm); reflexivity].
       destruct istart as [sstart | istart fstart].
       * destruct Histart as [Hlast HtrX].

--- a/VLSM/FullNode/Client.v
+++ b/VLSM/FullNode/Client.v
@@ -276,92 +276,10 @@ messages, implementing a limited equivocation tolerance policy.
       tauto.
   Qed.
 
-  (*
-  Lemma has_been_sent_in_trace
-    (s : set message)
-    (m: message)
-    (is : set message)
-    (tr: list transition_item)
-    (Htr: finite_protocol_trace bvlsm is tr)
-    (item: transition_item)
-    (Hitem: In item tr)
-    (Hm: output item = Some m)
-    (Hs: last (map destination tr) is = s)
-    : False.
-  Proof.
-    apply in_split in Hitem.
-    destruct Hitem as [l1 [l2 Hitem]]. subst tr.
-    destruct Htr as [Htr Hinit].
-    pose (finite_protocol_trace_from_app_iff bvlsm is l1 (item :: l2)) as Htr_app.
-    simpl in Htr_app. destruct Htr_app as [_ Htr_app].
-    specialize (Htr_app Htr).
-    clear Htr. destruct Htr_app as [_ Htr].
-    inversion Htr. subst tl item. simpl in Hm. subst oom.
-    apply protocol_transition_inv_out in H3. contradiction H3.
-  Qed.
-
-  Lemma VLSM_full_client_proper_sent
-    (s : set message)
-    (Hs : protocol_state_prop bvlsm s)
-    (m : message)
-    : has_been_sent_prop vlsm client_has_been_sent s m.
-  Proof.
-    unfold has_been_sent_prop. unfold all_traces_have_message_prop.
-    split;[contradiction|intro H].
-    - destruct Hs as [_om Hs].
-      pose (protocol_is_trace bvlsm s _om Hs) as Htr.
-      destruct Htr as [Hinit | [is [tr [Htr [Hlsts _]]]]].
-      + exfalso.
-        assert (Htrs : finite_protocol_trace bvlsm s []).
-        { split; try assumption. constructor. exists _om. assumption. }
-        specialize (H s [] Htrs eq_refl).
-        apply Exists_exists in H. destruct H as [x [Hin _]]. inversion Hin.
-      + assert (Hlst : last (map destination tr) is = s).
-        { destruct tr as [|i tr]; inversion Hlsts.
-          apply last_map.
-        }
-        specialize (H is tr Htr Hlst).
-        apply Exists_exists in H.
-        destruct H as [item [Hitem Hm]].
-        exfalso.
-        apply has_been_sent_in_trace with s m is tr item; assumption.
-  Qed.
-   *)
-
-  (*
-  Definition client_has_not_been_sent
-    (s : set message)
-    (m : message)
-    : Prop
-    :=
-    ~ client_has_been_sent s m.
-
-  Lemma VLSM_full_client_proper_not_sent
-    (s : set message)
-    (Hs : protocol_state_prop bvlsm s)
-    (m : message)
-    : has_not_been_sent_prop vlsm client_has_not_been_sent s m.
-  Proof.
-    unfold has_not_been_sent_prop. unfold no_traces_have_message_prop.
-    unfold client_has_not_been_sent. simpl.
-    split; intros;[|tauto].
-    unfold selected_message_exists_in_no_preloaded_trace.
-    unfold generalized_selected_message_exists_in_no_trace.
-    intros.
-    rewrite <- Forall_Exists_neg.
-    apply Forall_forall.
-    intros item Hitem Hm.
-    apply (has_been_sent_in_trace s m start tr Htr item Hitem Hm Hlast).
-  Qed.
-   *)
-
   Definition VLSM_full_client_has_been_sent
-    : has_been_sent_capability VLSM_full_client2.
-  Proof.
-    apply (has_been_sent_capability_from_stepwise client_has_been_sent).
-    apply VLSM_full_client_has_been_sent_step_properties.
-    exact client_has_been_sent_dec.
-  Defined.
+    : has_been_sent_capability VLSM_full_client2
+    := has_been_sent_capability_from_stepwise client_has_been_sent_dec
+                                              VLSM_full_client_has_been_sent_step_properties.
 
   Lemma has_been_received_in_trace
     (s : set message)

--- a/VLSM/FullNode/Client.v
+++ b/VLSM/FullNode/Client.v
@@ -260,6 +260,23 @@ messages, implementing a limited equivocation tolerance policy.
     :=
     fun s m => in_dec decide_eq m s.
 
+  Lemma VLSM_full_client_has_been_sent_step_properties:
+    has_been_sent_stepwise_props client_has_been_sent.
+  Proof.
+    unfold client_has_been_sent.
+    split.
+    - tauto.
+    - intros l s im s' om Hptrans msg.
+      assert (om <> Some msg).
+      {
+        destruct Hptrans as [_ Htrans].
+        cbn in Htrans.
+        destruct im;inversion Htrans;congruence.
+      }
+      tauto.
+  Qed.
+
+  (*
   Lemma has_been_sent_in_trace
     (s : set message)
     (m: message)
@@ -309,6 +326,42 @@ messages, implementing a limited equivocation tolerance policy.
         exfalso.
         apply has_been_sent_in_trace with s m is tr item; assumption.
   Qed.
+   *)
+
+  (*
+  Definition client_has_not_been_sent
+    (s : set message)
+    (m : message)
+    : Prop
+    :=
+    ~ client_has_been_sent s m.
+
+  Lemma VLSM_full_client_proper_not_sent
+    (s : set message)
+    (Hs : protocol_state_prop bvlsm s)
+    (m : message)
+    : has_not_been_sent_prop vlsm client_has_not_been_sent s m.
+  Proof.
+    unfold has_not_been_sent_prop. unfold no_traces_have_message_prop.
+    unfold client_has_not_been_sent. simpl.
+    split; intros;[|tauto].
+    unfold selected_message_exists_in_no_preloaded_trace.
+    unfold generalized_selected_message_exists_in_no_trace.
+    intros.
+    rewrite <- Forall_Exists_neg.
+    apply Forall_forall.
+    intros item Hitem Hm.
+    apply (has_been_sent_in_trace s m start tr Htr item Hitem Hm Hlast).
+  Qed.
+   *)
+
+  Definition VLSM_full_client_has_been_sent
+    : has_been_sent_capability VLSM_full_client2.
+  Proof.
+    apply cap_from_alt with client_has_been_sent.
+    apply VLSM_full_client_has_been_sent_step_properties.
+    exact client_has_been_sent_dec.
+  Defined.
 
   Lemma has_been_received_in_trace
     (s : set message)
@@ -349,38 +402,6 @@ messages, implementing a limited equivocation tolerance policy.
     apply set_add_iff. left. reflexivity.
   Qed.
 
-  Definition client_has_not_been_sent
-    (s : set message)
-    (m : message)
-    : Prop
-    :=
-    ~ client_has_been_sent s m.
-
-  Lemma VLSM_full_client_proper_not_sent
-    (s : set message)
-    (Hs : protocol_state_prop bvlsm s)
-    (m : message)
-    : has_not_been_sent_prop vlsm client_has_not_been_sent s m.
-  Proof.
-    unfold has_not_been_sent_prop. unfold no_traces_have_message_prop.
-    unfold client_has_not_been_sent. simpl.
-    split; intros;[|tauto].
-    unfold selected_message_exists_in_no_trace.
-    intros.
-    rewrite <- Forall_Exists_neg.
-    apply Forall_forall.
-    intros item Hitem Hm.
-    apply (has_been_sent_in_trace s m start tr Htr item Hitem Hm Hlast).
-  Qed.
-
-  Definition VLSM_full_client_has_been_sent
-    : has_been_sent_capability VLSM_full_client2
-    :=
-    {| has_been_sent := client_has_been_sent
-     ; proper_sent := VLSM_full_client_proper_sent
-     ; proper_not_sent := VLSM_full_client_proper_not_sent
-    |}.
-
   Lemma VLSM_full_client_proper_received
     (s : set message)
     (Hs : protocol_state_prop bvlsm s)
@@ -389,7 +410,7 @@ messages, implementing a limited equivocation tolerance policy.
   Proof.
     unfold has_been_received_prop. unfold all_traces_have_message_prop.
     unfold client_has_been_received.
-    unfold selected_message_exists_in_all_traces.
+    unfold selected_message_exists_in_all_preloaded_traces.
     unfold specialized_selected_message_exists_in_all_traces.
     split; intros.
     - apply Exists_exists.
@@ -451,7 +472,8 @@ messages, implementing a limited equivocation tolerance policy.
     unfold has_not_been_received_prop. unfold no_traces_have_message_prop.
     unfold client_has_not_been_received.
     unfold client_has_been_received.
-    unfold selected_message_exists_in_no_trace.
+    unfold selected_message_exists_in_no_preloaded_trace,
+       specialized_selected_message_exists_in_no_trace.
     split.
     - intros.
       rewrite <- Forall_Exists_neg.

--- a/VLSM/FullNode/Client.v
+++ b/VLSM/FullNode/Client.v
@@ -358,7 +358,7 @@ messages, implementing a limited equivocation tolerance policy.
   Definition VLSM_full_client_has_been_sent
     : has_been_sent_capability VLSM_full_client2.
   Proof.
-    apply cap_from_alt with client_has_been_sent.
+    apply (has_been_sent_capability_from_stepwise client_has_been_sent).
     apply VLSM_full_client_has_been_sent_step_properties.
     exact client_has_been_sent_dec.
   Defined.

--- a/VLSM/FullNode/Composite/Free.v
+++ b/VLSM/FullNode/Composite/Free.v
@@ -477,8 +477,8 @@ Lemma full_composed_free_sent_messages_comparable
   (Htr : finite_protocol_trace (pre_loaded_with_all_messages_vlsm VLSM_full_composed_free) s tr)
   (m1 m2 : message)
   (Hvalidator : sender m1 = sender m2)
-  (Hm1 : Equivocation.trace_has_message VLSM_full_composed_free output m1 tr)
-  (Hm2 : Equivocation.trace_has_message VLSM_full_composed_free output m2 tr)
+  (Hm1 : Equivocation.trace_has_message VLSM_full_composed_free (Equivocation.field_selector output) m1 tr)
+  (Hm2 : Equivocation.trace_has_message VLSM_full_composed_free (Equivocation.field_selector output) m2 tr)
   : m1 = m2 \/ validator_message_preceeds _ _ m1 m2 \/ validator_message_preceeds _ _ m2 m1.
 Proof.
   unfold Equivocation.trace_has_message in *.
@@ -497,7 +497,7 @@ Proof.
   - right. right. symmetry in Hvalidator. rewrite <- app_assoc in Hitem1. subst tr.
     apply
       (Hcomparable m2 m1 Hvalidator item2 item1 prefix2 suffix2 suffix1 eq_refl Hm2 Hm1).
-  - left. subst. rewrite Hm1 in Hm2. inversion Hm2. reflexivity.
+  - left. subst. simpl in Hm1, Hm2. rewrite Hm1 in Hm2. inversion Hm2. reflexivity.
   - right. left. subst tr.
     apply
       (Hcomparable m1 m2 Hvalidator item1 item2 prefix1 prefix2 suffix2 eq_refl Hm1 Hm2).

--- a/VLSM/FullNode/Validator.v
+++ b/VLSM/FullNode/Validator.v
@@ -635,8 +635,9 @@ Section proper_sent_received.
       destruct Hex as [item [Hitem Hout]].
       specialize (last_state_empty_trace is tr Htr Hlst item Hitem).
       intros [_ [Hnout _]].
+      simpl in Hout.
       rewrite Hnout in Hout. discriminate Hout.
-    - assert (Hm : selected_message_exists_in_some_preloaded_traces vlsm output s m).
+    - assert (Hm : selected_message_exists_in_some_preloaded_traces vlsm (field_selector output) s m).
       { exists is. exists tr. exists Htr. exists Hlst.
         apply Exists_exists.
         apply (has_been_sent_in_trace_rev s m H is tr Htr Hlst).
@@ -654,8 +655,8 @@ Section proper_sent_received.
     (s : vstate vlsm)
     (Hs : protocol_state_prop bvlsm s)
     (m : message)
-    : selected_message_exists_in_some_preloaded_traces vlsm output s m <->
-    selected_message_exists_in_all_preloaded_traces vlsm output s m.
+    : selected_message_exists_in_some_preloaded_traces vlsm (field_selector output) s m <->
+    selected_message_exists_in_all_preloaded_traces vlsm (field_selector output) s m.
   Proof.
     specialize (sent_messages_prop s Hs m) as Hin.
     split; intros.
@@ -667,7 +668,7 @@ Section proper_sent_received.
     - destruct Hs as [_om Hs].
       pose (protocol_is_trace bvlsm s _om Hs) as Htr.
       destruct Htr as [Hinit | [is [tr [Htr [Hlsts _]]]]].
-      + specialize (selected_message_exists_in_all_traces_initial_state vlsm s Hinit output m) as Hsm.
+      + specialize (selected_message_exists_in_all_traces_initial_state vlsm s Hinit (field_selector output) m) as Hsm.
         elim Hsm. assumption.
       + exists is. exists tr. exists Htr.
         assert (Hlst : last (List.map destination tr) is = s).
@@ -701,7 +702,7 @@ Section proper_sent_received.
     destruct Hs as [_om Hs].
     pose (protocol_is_trace bvlsm s _om Hs) as Htr.
     destruct Htr as [Hinit | [is [tr [Htr [Hlsts _]]]]].
-    + elim (selected_message_exists_in_all_traces_initial_state vlsm s Hinit output m).
+    + elim (selected_message_exists_in_all_traces_initial_state vlsm s Hinit (field_selector output) m).
       assumption.
     + assert (Hlst : last (map destination tr) is = s).
       { destruct tr as [|i tr]; inversion Hlsts.
@@ -856,7 +857,7 @@ Section proper_sent_received.
     exists (sm : received_messages vlsm s), proj1_sig sm = m.
   Proof.
     split; intros.
-    - assert (Hm : selected_message_exists_in_some_preloaded_traces vlsm input s m)
+    - assert (Hm : selected_message_exists_in_some_preloaded_traces vlsm (field_selector input) s m)
       ; try (exists (exist _ m Hm); reflexivity).
       destruct Hs as [_om Hs].
       pose (protocol_is_trace bvlsm s _om Hs) as Htr.
@@ -878,8 +879,8 @@ Section proper_sent_received.
     (s : vstate vlsm)
     (Hs : protocol_state_prop bvlsm s)
     (m : message)
-    : selected_message_exists_in_some_preloaded_traces vlsm input s m <->
-    selected_message_exists_in_all_preloaded_traces vlsm input s m.
+    : selected_message_exists_in_some_preloaded_traces vlsm (field_selector input) s m <->
+    selected_message_exists_in_all_preloaded_traces vlsm (field_selector input) s m.
   Proof.
     specialize (received_messages_prop s Hs m) as Hin.
     split; intros.
@@ -891,7 +892,7 @@ Section proper_sent_received.
     - destruct Hs as [_om Hs].
       pose (protocol_is_trace bvlsm s _om Hs) as Htr.
       destruct Htr as [Hinit | [is [tr [Htr [Hlsts _]]]]].
-      + specialize (selected_message_exists_in_all_traces_initial_state vlsm s Hinit input m) as Hsm.
+      + specialize (selected_message_exists_in_all_traces_initial_state vlsm s Hinit (field_selector input) m) as Hsm.
         elim Hsm. assumption.
       + exists is. exists tr. exists Htr.
         assert (Hlst : last (List.map destination tr) is = s).
@@ -958,8 +959,8 @@ Section proper_sent_received.
     (tr : list transition_item)
     (Htr : finite_protocol_trace bvlsm s tr)
     (m1 m2 : message)
-    (Hm1 : Equivocation.trace_has_message vlsm output m1 tr)
-    (Hm2 : Equivocation.trace_has_message vlsm output m2 tr)
+    (Hm1 : Equivocation.trace_has_message vlsm (field_selector output) m1 tr)
+    (Hm2 : Equivocation.trace_has_message vlsm (field_selector output) m2 tr)
     : m1 = m2 \/ validator_message_preceeds _ _ m1 m2 \/ validator_message_preceeds _ _ m2 m1.
   Proof.
     unfold Equivocation.trace_has_message in *.
@@ -981,7 +982,7 @@ Section proper_sent_received.
           s tr Htr prefix2 suffix2 suffix1 item2 item1 Hitem1
           m2 m1 Hm2 Hm1
         ).
-    - left. subst. rewrite Hm1 in Hm2. inversion Hm2. reflexivity.
+    - left. subst. simpl in Hm1, Hm2. rewrite Hm1 in Hm2. inversion Hm2. reflexivity.
     - right. left.
       apply
         (VLSM_full_validator_sent_messages_comparable'

--- a/VLSM/FullNode/Validator.v
+++ b/VLSM/FullNode/Validator.v
@@ -629,14 +629,14 @@ Section proper_sent_received.
     ; try assert (Hlst : last (List.map destination tr) is = s)
       by (destruct tr as [|i tr]; inversion Hdest; apply last_map)
     .
-    - destruct x as [m0 Hm0]. unfold selected_message_exists_in_some_traces in Hm0.
-      destruct Hm0 as [is [tr [Htr [Hlst Hex]]]]. simpl in *.
+    - destruct x as [m0 Hm0].
+      destruct Hm0 as [is [tr [Htr [Hlst Hex]]]];simpl in *.
       apply Exists_exists in Hex.
       destruct Hex as [item [Hitem Hout]].
       specialize (last_state_empty_trace is tr Htr Hlst item Hitem).
       intros [_ [Hnout _]].
       rewrite Hnout in Hout. discriminate Hout.
-    - assert (Hm : selected_message_exists_in_some_traces vlsm output s m).
+    - assert (Hm : selected_message_exists_in_some_preloaded_traces vlsm output s m).
       { exists is. exists tr. exists Htr. exists Hlst.
         apply Exists_exists.
         apply (has_been_sent_in_trace_rev s m H is tr Htr Hlst).
@@ -654,8 +654,8 @@ Section proper_sent_received.
     (s : vstate vlsm)
     (Hs : protocol_state_prop bvlsm s)
     (m : message)
-    : selected_message_exists_in_some_traces vlsm output s m <->
-    selected_message_exists_in_all_traces vlsm output s m.
+    : selected_message_exists_in_some_preloaded_traces vlsm output s m <->
+    selected_message_exists_in_all_preloaded_traces vlsm output s m.
   Proof.
     specialize (sent_messages_prop s Hs m) as Hin.
     split; intros.
@@ -856,7 +856,7 @@ Section proper_sent_received.
     exists (sm : received_messages vlsm s), proj1_sig sm = m.
   Proof.
     split; intros.
-    - assert (Hm : selected_message_exists_in_some_traces vlsm input s m)
+    - assert (Hm : selected_message_exists_in_some_preloaded_traces vlsm input s m)
       ; try (exists (exist _ m Hm); reflexivity).
       destruct Hs as [_om Hs].
       pose (protocol_is_trace bvlsm s _om Hs) as Htr.
@@ -878,8 +878,8 @@ Section proper_sent_received.
     (s : vstate vlsm)
     (Hs : protocol_state_prop bvlsm s)
     (m : message)
-    : selected_message_exists_in_some_traces vlsm input s m <->
-    selected_message_exists_in_all_traces vlsm input s m.
+    : selected_message_exists_in_some_preloaded_traces vlsm input s m <->
+    selected_message_exists_in_all_preloaded_traces vlsm input s m.
   Proof.
     specialize (received_messages_prop s Hs m) as Hin.
     split; intros.

--- a/VLSM/ListValidator/Equivocation.v
+++ b/VLSM/ListValidator/Equivocation.v
@@ -1679,7 +1679,7 @@ Context
     Proof.
       unfold has_been_sent_prop.
       unfold all_traces_have_message_prop.
-      unfold selected_message_exists_in_all_traces.
+      unfold selected_message_exists_in_all_preloaded_traces.
       unfold specialized_selected_message_exists_in_all_traces.
       split.
       - intros.
@@ -1945,7 +1945,7 @@ Context
     Proof.
       unfold has_been_received_prop.
       unfold all_traces_have_message_prop.
-      unfold selected_message_exists_in_all_traces.
+      unfold selected_message_exists_in_all_preloaded_traces.
       unfold specialized_selected_message_exists_in_all_traces.
       split.
       - intros.
@@ -2224,7 +2224,8 @@ Context
       intros.
       unfold has_not_been_sent_prop.
       unfold no_traces_have_message_prop.
-      unfold selected_message_exists_in_no_trace.
+      unfold selected_message_exists_in_no_preloaded_trace,
+          specialized_selected_message_exists_in_no_trace.
       split.
       - intros.
         unfold not_send_oracle in H.
@@ -2332,7 +2333,8 @@ Context
       intros.
       unfold has_not_been_received_prop.
       unfold no_traces_have_message_prop.
-      unfold selected_message_exists_in_no_trace.
+      unfold selected_message_exists_in_no_preloaded_trace,
+          specialized_selected_message_exists_in_no_trace.
       split.
       - intros.
         unfold not_receive_oracle in H.

--- a/VLSM/Liveness.v
+++ b/VLSM/Liveness.v
@@ -145,7 +145,7 @@ Currently we define only a strong assumption that doesn't allow
 any messages to be delayed, which will be used for example proofs of
 liveness.
 
-Definitions allowing a limited rate of "syncrhonization faults" will
+Definitions allowing a limited rate of "synchronization faults" will
 be added before verifying more robust protocols over more realistic
 assumptions.
  *)
@@ -161,7 +161,7 @@ Section StrongSynchrony.
     (Hi : index)
     (constraint : composite_label IM -> composite_state IM * option message -> Prop)
     {Hsents : forall i, has_been_sent_capability (IM i)}
-    (has_been_observed_op: forall i, state_message_oracle (IM i))
+    {Hobserveds: forall i, has_been_observed_capability (IM i)}
     (clocks : ClocksFor IM)
     (message_time : message -> nat)
   .
@@ -186,7 +186,7 @@ Section StrongSynchrony.
   Definition all_earlier_messages_received (i:index) (s:composite_state IM) : Prop :=
     forall msg, (exists (j:index), has_been_sent (IM j) (s j) msg) ->
                 message_time msg <= clock _ (clocks i) (s i) ->
-                has_been_observed_op i (s i) msg.
+                has_been_observed (IM i) (s i) msg.
 
   (** This portion of a constraint prevents a component from advancing its clock
       if it has not received all oustanding messages from the time

--- a/VLSM/Liveness/SimpleFragileProtocol.v
+++ b/VLSM/Liveness/SimpleFragileProtocol.v
@@ -249,27 +249,17 @@ Section Define_Component.
 
   Definition validator_sent_stepwise_props:
     has_been_sent_stepwise_props validator_has_been_sent :=
-    {| inits_no_sent := validator_initial_not_sent;
-       sent_step_update l s im s' om H :=
+    {| oracle_no_inits := validator_initial_not_sent;
+       oracle_step_update l s im s' om H :=
          (validator_transition_updates_sent l s im s' om (proj2 H));
     |}.
 
-  Definition validator_proper_sent :=
-    prove_proper_sent_from_stepwise
-      _ _ validator_has_been_sent
-      validator_sent_stepwise_props.
-  Definition validator_proper_not_sent :=
-    prove_proper_not_sent_from_stepwise
-      _ _ validator_has_been_sent
-      validator_sent_stepwise_props.
-
-  Global Instance validator_has_been_sent_capability : has_been_sent_capability Validator
-    :=
-      { has_been_sent := validator_has_been_sent;
-        has_been_sent_dec := validator_has_been_sent_dec;
-        proper_sent := validator_proper_sent;
-        proper_not_sent := validator_proper_not_sent;
-      }.
+  Global Instance validator_has_been_sent_capability : has_been_sent_capability Validator.
+  Proof.
+    eapply has_been_sent_capability_from_stepwise.
+    eapply validator_sent_stepwise_props.
+    exact validator_has_been_sent_dec.
+  Defined.
 
   (** N.B. this is not actually a [has_been_received_capability],
       because a validator counts a message as "received" when it

--- a/VLSM/Liveness/SimpleFragileProtocol.v
+++ b/VLSM/Liveness/SimpleFragileProtocol.v
@@ -247,16 +247,21 @@ Section Define_Component.
       firstorder congruence.
   Qed.
 
+  Definition validator_sent_stepwise_props:
+    has_been_sent_stepwise_props validator_has_been_sent :=
+    {| inits_no_sent := validator_initial_not_sent;
+       sent_step_update l s im s' om H :=
+         (validator_transition_updates_sent l s im s' om (proj2 H));
+    |}.
+
   Definition validator_proper_sent :=
     prove_proper_sent_from_stepwise
       _ _ validator_has_been_sent
-      validator_initial_not_sent
-      validator_transition_updates_sent.
+      validator_sent_stepwise_props.
   Definition validator_proper_not_sent :=
     prove_proper_not_sent_from_stepwise
       _ _ validator_has_been_sent
-      validator_initial_not_sent
-      validator_transition_updates_sent.
+      validator_sent_stepwise_props.
 
   Global Instance validator_has_been_sent_capability : has_been_sent_capability Validator
     :=

--- a/VLSM/Liveness/SimpleFragileProtocol.v
+++ b/VLSM/Liveness/SimpleFragileProtocol.v
@@ -254,17 +254,11 @@ Section Define_Component.
          (validator_transition_updates_sent l s im s' om (proj2 H));
     |}.
 
-  Global Instance validator_has_been_sent_capability : has_been_sent_capability Validator.
-  Proof.
-    eapply has_been_sent_capability_from_stepwise.
-    eapply validator_sent_stepwise_props.
-    exact validator_has_been_sent_dec.
-  Defined.
+  Global Instance validator_has_been_sent_capability : has_been_sent_capability Validator
+    := has_been_sent_capability_from_stepwise
+         validator_has_been_sent_dec
+         validator_sent_stepwise_props.
 
-  (** N.B. this is not actually a [has_been_received_capability],
-      because a validator counts a message as "received" when it
-      sends it itself
-   *)
   Definition validator_has_been_observed : validator_state -> validator_message -> Prop.
   Proof using.
     exact (fun '(State _ received _ _) m => In m received).
@@ -284,9 +278,9 @@ Section Define_Component.
 
   Lemma validator_transition_updates_observed:
        forall l s im s' om,
-         protocol_transition Validator l (s,im) (s',om) ->
+         protocol_transition (pre_loaded_with_all_messages_vlsm Validator) l (s,im) (s',om) ->
          forall msg, validator_has_been_observed s' msg
-                     <-> (im = Some msg \/ om = Some msg \/ validator_has_been_observed s msg).
+                     <-> ((im = Some msg \/ om = Some msg) \/ validator_has_been_observed s msg).
   Proof using.
     intros l s im s' om [[_ [_ Hvalid]] Htrans] msg.
     destruct s.
@@ -307,6 +301,18 @@ Section Define_Component.
       destruct v0.
       firstorder congruence.
   Qed.
+
+  Definition validator_observed_stepwise_props :
+    oracle_stepwise_props (vlsm:=Validator) item_sends_or_receives validator_has_been_observed
+    := {| oracle_no_inits := validator_initial_not_observed;
+          oracle_step_update := validator_transition_updates_observed|}.
+
+  Global Instance validator_has_been_observed_capability:
+    has_been_observed_capability Validator :=
+      {|has_been_observed := validator_has_been_observed: state_message_oracle Validator;
+        has_been_observed_dec := validator_has_been_observed_dec;
+        has_been_observed_stepwise_props :=
+          validator_observed_stepwise_props |}.
 End Define_Component.
 
 (** * Composition and Proofs
@@ -369,7 +375,6 @@ Section Protocol_Proofs.
   Context
     (constraint : composite_label IM -> composite_state IM * option (validator_message C V) -> Prop
        := no_synch_faults_no_equivocation_constraint v0 validators_finite IM
-                 (fun v => validator_has_been_observed C V:state_message_oracle (IM v))
                  (validator_clock C V c0 plan estimator)
              message_time)
     (X: VLSM (validator_message C V) := composite_vlsm IM v0 constraint)

--- a/VLSM/PreceedsEquivocation.v
+++ b/VLSM/PreceedsEquivocation.v
@@ -237,8 +237,8 @@ Section vlsm_message_equivocation_evidence.
         (s : state)
         (tr : list transition_item)
         (Htr : finite_protocol_trace (pre_loaded_with_all_messages_vlsm X) s tr)
-        (Hm1 : trace_has_message X input m1 tr)
-        (Hm2 : trace_has_message X input m2 tr)
+        (Hm1 : trace_has_message X (field_selector input) m1 tr)
+        (Hm2 : trace_has_message X (field_selector input) m2 tr)
         : equivocation_in_trace X m1 tr
         \/ equivocation_in_trace X m2 tr
     }.


### PR DESCRIPTION
This proves the equivalence of the trace-based and stepwise definitions of correctness for `state_message_oracle`, and generalizes definitions so the proofs are also usable for `has_been_received`, and the new `has_been_observed` property.

As `has_been_observed` covers both messages sent and received, the `message_selector` argument of some trace properties had to be made more general than `transition_item -> option message`. I generalized to `message -> transition_item -> Prop`, but perhaps we should generalize some of the definitions further to just take a `transition_item -> Prop` predicate, rather than having definitions like `all_traces_have_message_prop` thread along a message argument as they do now.