### PR TITLE
Equivocation refactorings and full node condition

### DIFF
--- a/VLSM/Equivocators/Common.v
+++ b/VLSM/Equivocators/Common.v
@@ -72,6 +72,31 @@ Definition mk_singleton_state
   :=
   existT _ 0 (fun _ => s).
 
+Definition is_singleton_state
+  (s : equivocator_state)
+  : Prop
+  := projT1 s = 0.
+
+Lemma is_singleton_state_dec
+  (s : equivocator_state)
+  : Decision (is_singleton_state s).
+Proof.
+  apply nat_eq_dec.
+Qed.
+
+Definition is_equivocating_state
+  (s : equivocator_state)
+  : Prop
+  := not (is_singleton_state s).
+
+Lemma is_equivocating_state_dec
+  (s : equivocator_state)
+  : Decision (is_equivocating_state s).
+Proof.
+  apply Decision_not.
+  apply is_singleton_state_dec.
+Qed.
+
 Definition equivocator_label : Type := @label message equivocator_type.
 
 Definition mk_label

--- a/VLSM/Equivocators/Composition/Common.v
+++ b/VLSM/Equivocators/Composition/Common.v
@@ -75,6 +75,14 @@ Context
   (equivocators_free_Hbs : has_been_sent_capability equivocators_free_vlsm := composite_has_been_sent_capability equivocator_IM i0 (free_constraint equivocator_IM) finite_index equivocator_Hbs)
   .
 
+Existing Instance is_equivocating_state_dec.
+
+Definition equivocating_indices
+  (s : composite_state equivocator_IM)
+  : list index
+  :=
+  filter (fun i => bool_decide (is_equivocating_state (IM i) (s i))) index_listing.
+
 Existing Instance equivocators_free_Hbs.
 
 Definition equivocators_no_equivocations_constraint

--- a/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -103,9 +103,9 @@ Definition sent_by_non_equivocating
     (Hi : ~In i equivocating),
     has_been_sent (IM i) (s i) m.
 
-Definition non_equivocating_seeded_free_equivocators_composition
-  (s : composite_state IM)
-  := vlsm_add_initial_messages free_equivocating_vlsm_composition (sent_by_non_equivocating s).
+Definition seeded_free_equivocators_composition
+  (messageSet : message -> Prop)
+  := vlsm_add_initial_messages free_equivocating_vlsm_composition messageSet.
 
   Context
     {validator : Type}
@@ -129,7 +129,7 @@ Definition fixed_equivocation_constraint
     | Some v =>
       let i := A v in
       if index_equivocating_prop_dec i
-      then protocol_message_prop (non_equivocating_seeded_free_equivocators_composition s) m
+      then protocol_message_prop (seeded_free_equivocators_composition (sent_by_non_equivocating s)) m
       else has_been_sent (IM i) (s i) m
     end
   end.

--- a/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -1,0 +1,140 @@
+Require Import
+  List Coq.Vectors.Fin FinFun ListSet
+  Arith.Compare_dec Lia
+  Program Program.Equality
+  Coq.Logic.JMeq
+  .
+Import ListNotations.
+From CasperCBC
+  Require Import
+    Preamble ListExtras FinExtras
+    VLSM.Common VLSM.Composition VLSM.Equivocation
+    VLSM.Equivocators.Common VLSM.Equivocators.Projections
+    VLSM.Equivocators.MessageProperties
+    VLSM.Equivocators.Composition.Common
+    .
+
+Section equivocators_fixed_equivocations_vlsm.
+
+Context
+  {message : Type}
+  (index : Type)
+  {IndEqDec : EqDecision index}
+  (IM : index -> VLSM message)
+  (Hbs : forall i : index, has_been_sent_capability (IM i))
+  (i0 : index)
+  (equivocator_IM := equivocator_IM IM)
+  (index_listing : list index)
+  (finite_index : Listing index_listing)
+  (equivocating : set index)
+  .
+
+Definition equivocators_fixed_equivocations_constraint
+  (l : composite_label equivocator_IM)
+  (som : composite_state equivocator_IM * option message)
+  (som' := composite_transition equivocator_IM l som)
+  : Prop
+  := equivocators_no_equivocations_constraint IM Hbs i0 index_listing finite_index l som
+  /\ incl (equivocating_indices IM index_listing (fst som')) equivocating.
+
+Definition equivocators_fixed_equivocations_vlsm
+  : VLSM message
+  :=
+  equivocators_constrained_vlsm IM i0 equivocators_fixed_equivocations_constraint.
+
+End equivocators_fixed_equivocations_vlsm.
+
+Section fixed_equivocation_without_fullnode.
+
+Context {message : Type}
+  (index : Type)
+  {IndEqDec : EqDecision index}
+  (IM : index -> VLSM message)
+  (Hbs : forall i : index, has_been_sent_capability (IM i))
+  (i0 : index)
+  (X := free_composite_vlsm IM i0)
+  (index_listing : list index)
+  (finite_index : Listing index_listing)
+  (equivocators_choice := equivocators_choice IM)
+  (equivocators_state_project := equivocators_state_project IM i0)
+  (equivocator_IM := equivocator_IM IM)
+  (equivocators_choice_update := equivocators_choice_update IM)
+  (proper_equivocators_choice := proper_equivocators_choice IM i0)
+  (equivocating : set index)
+  (i0_equiv : index)
+  (Hi0_equiv : In i0_equiv equivocating)
+  .
+
+Definition index_equivocating_prop (i : index) : Prop := In i equivocating.
+
+Local Instance index_equivocating_prop_dec
+  (i : index)
+  : Decision (index_equivocating_prop i).
+Proof.
+  apply in_dec. assumption.
+Qed.
+
+Definition equivocating_index : Type
+  := dec_sig index_equivocating_prop.
+
+Definition equivocating_i0 : equivocating_index
+  := (@dec_exist _ _ index_equivocating_prop_dec _ Hi0_equiv).
+
+Local Instance equivocating_index_eq_dec : EqDecision equivocating_index.
+Proof.
+  apply dec_sig_eq_dec. assumption.
+Qed.
+
+Definition equivocating_IM
+  (ei : equivocating_index)
+  : VLSM message
+  := IM (proj1_sig ei).
+
+Definition free_equivocating_vlsm_composition : VLSM message
+  := free_composite_vlsm equivocating_IM equivocating_i0.
+
+Definition sent_by_non_equivocating
+  (s : composite_state IM)
+  (m : message)
+  : Prop
+  :=
+  exists
+    (i : index)
+    (Hi : ~In i equivocating),
+    has_been_sent (IM i) (s i) m.
+
+Definition non_equivocating_seeded_free_equivocators_composition
+  (s : composite_state IM)
+  := vlsm_add_initial_messages free_equivocating_vlsm_composition (sent_by_non_equivocating s).
+
+  Context
+    {validator : Type}
+    (A : validator -> index)
+    (sender : message -> option validator)
+    (Hsender_safety : Prop := sender_safety_prop IM i0 (free_constraint IM) A sender)
+    .
+
+Definition fixed_equivocation_constraint
+  (l : composite_label IM)
+  (som : composite_state IM * option message)
+  : Prop
+  :=
+  let (s, om) := som in
+  match om with
+  | None => True
+  | Some m =>
+    let ov := sender m in
+    match ov with
+    | None => composite_initial_message_prop IM m
+    | Some v =>
+      let i := A v in
+      if index_equivocating_prop_dec i
+      then protocol_message_prop (non_equivocating_seeded_free_equivocators_composition s) m
+      else has_been_sent (IM i) (s i) m
+    end
+  end.
+
+Definition fixed_equivocation_vlsm_composition : VLSM message
+  := composite_vlsm IM i0 fixed_equivocation_constraint.
+
+End fixed_equivocation_without_fullnode.

--- a/VLSM/Equivocators/Composition/LimitedEquivocation/LimitedEquivocation.v
+++ b/VLSM/Equivocators/Composition/LimitedEquivocation/LimitedEquivocation.v
@@ -1,0 +1,53 @@
+Require Import
+  List Coq.Vectors.Fin FinFun ListSet
+  Arith.Compare_dec Lia Reals
+  Program
+  Coq.Logic.JMeq
+  .
+Import ListNotations.
+From CasperCBC
+  Require Import
+    Preamble ListExtras FinExtras
+    CBC.Common
+    VLSM.Common VLSM.Composition VLSM.Equivocation
+    VLSM.Equivocators.Common VLSM.Equivocators.Projections
+    VLSM.Equivocators.MessageProperties
+    VLSM.Equivocators.Composition.Common
+    .
+
+Section equivocators_composition_projections.
+
+Context {message : Type}
+  (index := Type)
+  {IndEqDec : EqDecision index}
+  (IM : index -> VLSM message)
+  (Hbs : forall i : index, has_been_sent_capability (IM i))
+  (i0 : index)
+  (X := free_composite_vlsm IM i0)
+  (index_listing : list index)
+  (finite_index : Listing index_listing)
+  (equivocators_choice := equivocators_choice IM)
+  (equivocators_state_project := equivocators_state_project IM i0)
+  (equivocator_IM := equivocator_IM IM)
+  (equivocators_choice_update := equivocators_choice_update IM)
+  (proper_equivocators_choice := proper_equivocators_choice IM i0)
+  {Hmeasurable : Measurable index}
+  (equivocating : set index)
+  {reachable_threshold : ReachableThreshold index}
+  .
+
+Definition equivocators_limited_equivocations_constraint
+  (l : composite_label equivocator_IM)
+  (som : composite_state equivocator_IM * option message)
+  (som' := composite_transition equivocator_IM l som)
+  : Prop
+  := equivocators_no_equivocations_constraint IM Hbs i0 index_listing finite_index l som
+  /\ (sum_weights (equivocating_indices IM index_listing (fst som'))
+      <= proj1_sig threshold)%R.
+
+Definition equivocators_limited_equivocations_vlsm
+  : VLSM message
+  :=
+  equivocators_constrained_vlsm IM i0 equivocators_limited_equivocations_constraint.
+
+End equivocators_composition_projections.

--- a/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -998,7 +998,6 @@ Proof.
     as Hepref_free.
   specialize (finite_ptrace_last_pstate _ _ _ Hepref_free) as Hlast_free.
   destruct (input eitem) as [m|] eqn:Hinput; [|exact I].
-  apply specialized_proper_sent; [assumption|].
   apply finite_ptrace_first_valid_transition in Hesuf as Hitem.
   destruct Hitem as [[Hs [Hinp [_ Heqv] ]] _].
   rewrite Hleitem in Heqv. clear Hleitem.
@@ -1006,6 +1005,8 @@ Proof.
   unfold equivocators_no_equivocations_constraint at 1.
   unfold no_equivocations in Heqv.
   rewrite Hinput in Heqv.
+  destruct Heqv as [Heqv | Hinitial]; [| right; assumption].
+  left. apply specialized_proper_sent; [assumption|].
   apply specialized_proper_sent_rev in Heqv
   ; [|
      destruct Hs as [_om Hs]; apply constraint_free_protocol_prop in Hs; exists _om; assumption

--- a/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -45,18 +45,6 @@ Local Tactic Notation "unfold_transition"  hyp(Ht) :=
   unfold machine in Ht; unfold projT2 in Ht;
   unfold equivocator_vlsm_machine in Ht; unfold equivocator_transition in Ht).
 
-Context
-  (Hno_initial : forall (m : message) (eqv : equiv_index), ~vinitial_message_prop (IM (eqv)) m)
-  .
-
-Lemma equivocators_no_equivocations_vlsm_no_initial_message
-  (m : message)
-  : ~vinitial_message_prop equivocators_no_equivocations_vlsm m.
-Proof.
-  intros [eqv [[mi Hmi] Hi]]. simpl in Hi. subst mi.
-  elim (Hno_initial m eqv). assumption.
-Qed.
-
 Lemma equivocators_trace_project_skip_full_replay_trace_init'
   (full_replay_state : vstate equivocators_no_equivocations_vlsm)
   (eqv_choice: equivocators_choice)
@@ -576,25 +564,25 @@ Proof.
         simpl in Hv. destruct Hv as [Hv _].
         assumption.
       - unfold om in *. destruct (snd (final msg_run)) eqn:Hm; [|exact I].
-        apply specialized_proper_sent.
-        {
-          specialize (finite_ptrace_last_pstate equivocators_no_equivocations_vlsm _ _ Happ)
-            as Hlst.
-          destruct Hlst as [_om Hlst].
-          exists _om.
-          apply (constraint_subsumption_protocol_prop equivocator_IM i0 _ (free_constraint equivocator_IM))
-            in Hlst; [|intro; intros; exact I].
-          rewrite map_app in Hlst.
-          rewrite last_app in Hlst. simpl in Hlst.
-          rewrite Heqv_state_final in Hlst.
-          subst.
-          assumption.
-        }
         destruct (null_dec (transitions eqv_msg_run)).
-        + elim (equivocators_no_equivocations_vlsm_no_initial_message m).
+        + right.
           apply (vlsm_run_no_transitions_output equivocators_no_equivocations_vlsm)
             with (run := eqv_msg_run); assumption.
-        + specialize
+        + left. apply specialized_proper_sent.
+          {
+            specialize (finite_ptrace_last_pstate equivocators_no_equivocations_vlsm _ _ Happ)
+              as Hlst.
+            destruct Hlst as [_om Hlst].
+            exists _om.
+            apply (constraint_subsumption_protocol_prop equivocator_IM i0 _ (free_constraint equivocator_IM))
+              in Hlst; [|intro; intros; exact I].
+            rewrite map_app in Hlst.
+            rewrite last_app in Hlst. simpl in Hlst.
+            rewrite Heqv_state_final in Hlst.
+            subst.
+            assumption.
+          }
+          specialize
             (vlsm_run_last_final equivocators_no_equivocations_vlsm (exist _ _ Heqv_msg_run))
             as Hfinal.
           simpl in Hfinal.

--- a/VLSM/FullNode/Client.v
+++ b/VLSM/FullNode/Client.v
@@ -202,6 +202,9 @@ messages, implementing a limited equivocation tolerance policy.
     inversion He.
   Qed.
   Next Obligation.
+  inversion His.
+  Qed.
+  Next Obligation.
     unfold vtransition in Ht. simpl in Ht. destruct o; congruence.
   Qed.
 

--- a/VLSM/FullNode/Validator.v
+++ b/VLSM/FullNode/Validator.v
@@ -216,6 +216,7 @@ Section CompositeValidator.
     split; intros.
     - replace s with (@nil message, @None message) in He by assumption.
       inversion He.
+    - inversion His.
     - destruct som as (s, om). destruct s as (msgs, final).
       destruct l as [c|]; [|destruct om as [msg|]]; inversion Ht.
       subst. clear Ht.

--- a/VLSM/Liveness/SimpleFragileProtocol.v
+++ b/VLSM/Liveness/SimpleFragileProtocol.v
@@ -608,7 +608,7 @@ Section Protocol_Proofs.
          : has_been_sent_capability X) as Hhbs.
     pose (composite_has_been_observed_capability _ _ _ validators_finite _
          : has_been_observed_capability X) as Hhbo.
-    assert (observed_were_sent _ X _ _ s).
+    assert (observed_were_sent_or_initial _ X _ _ s).
     {
       apply observed_were_sent_invariant;[|assumption].
       clear.
@@ -617,6 +617,7 @@ Section Protocol_Proofs.
     }
     intros i msg Hi.
     specialize (H0 msg (ex_intro _ i Hi)).
+    destruct H0 as [H0 | [k [[mk Hmk] H0]]]; [|inversion Hmk].
     destruct H0 as [j Hj].
     (* The [observed_were_sent_invariant] only says that
        some component sent the message.
@@ -864,7 +865,9 @@ Section Protocol_Proofs.
       apply Plus.plus_lt_compat_r.
 
       rename Hvalid into Hcomposite_valid.
-      destruct (id Hcomposite_valid) as [Hproto [_ [Hvalidator_valid [[ix Hsent] _]]]].
+      destruct (id Hcomposite_valid)
+        as [Hproto [_ [Hvalidator_valid [[[ix Hsent]| [k [[mk Hmk] _]]] _]]]]
+        ; [| inversion Hmk].
       simpl in Hvalidator_valid.
       (* The validity condition ensures that the exact
          message has not been received before, but to

--- a/_CoqProject
+++ b/_CoqProject
@@ -17,6 +17,8 @@ VLSM/Equivocators/Composition/Common.v
 VLSM/Equivocators/Composition/Projections.v
 VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
 VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+VLSM/Equivocators/Composition/LimitedEquivocation/LimitedEquivocation.v
 VLSM/Equivocation.v
 VLSM/PreceedsEquivocation.v
 VLSM/ObservableEquivocation.v


### PR DESCRIPTION
* Changed the `no_equivocations` constraint to allow receiving initial messages
* Added results relating `has_been_sent` and `has_been_received` with `has_been_observed`.
* Defined `has_been_received` capabilities for composition based on the ones for individual nodes
* Defined a full-node-like constraint based on `has_been_...` capabilities
* Added initial definitions for FixedSetEquivocation composition of equivocators and LimitedEquivocation composition of equivocators.
  * includes the constrained proposed by @mcalancea  for modelling FixedSetEquivocation.