### PR TITLE
Relating Full-node-like conditions

### DIFF
--- a/VLSM/ByzantineTraces.v
+++ b/VLSM/ByzantineTraces.v
@@ -455,7 +455,7 @@ Lemma [pre_loaded_with_all_messages_composite_free_protocol_message] above to pr
         apply basic_VLSM_incl
         ; intros; try (assumption || reflexivity).
         - apply pre_loaded_with_all_messages_composite_free_protocol_message with l s.
-          destruct H as [_ [_ Hv]]. assumption.
+          assumption.
         - intros. destruct H as [_ [_ [Hv Hc]]].
           split; try assumption.
           exact I.

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -2323,7 +2323,7 @@ Proof.
   destruct HX as (sm & [s im] & l & HX).
   pose proof (finite_ptrace_singleton _ HX).
   apply finite_protocol_trace_from_complete_left in H.
-  destruct H as [is [trs Htr]].
+  destruct H as [is [trs [Htr _]]].
   apply (Hincl (Finite _ _)) in Htr.
   apply can_emit_from_protocol_trace with (m0:=m) in Htr.
   assumption.

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -586,9 +586,7 @@ Then <<X1>> is trace-included into <<X2>>.
     Proof.
       apply (basic_VLSM_incl (machine X1) (machine X2))
       ; intros; try (assumption || reflexivity).
-      - destruct H as [_ [[_s Hom] _]]. exists _s.
-        apply preloaded_constraint_subsumption_protocol_prop.
-        assumption.
+      - apply initial_message_is_protocol;assumption.
       - apply preloaded_constraint_subsumption_protocol_valid.
         assumption.
     Qed.
@@ -598,8 +596,7 @@ Then <<X1>> is trace-included into <<X2>>.
     Proof.
       apply (basic_VLSM_incl (machine (pre_loaded_with_all_messages_vlsm X1)) (machine (pre_loaded_with_all_messages_vlsm X2)))
       ; intros; try (assumption || reflexivity).
-      - destruct H as [_ [[_s Hom] _]]. exists _s.
-        apply preloaded_constraint_subsumption_preloaded_protocol_prop. assumption.
+      - apply initial_message_is_protocol; assumption.
       - apply preloaded_constraint_subsumption_preloaded_protocol_valid.
         assumption.
     Qed.
@@ -911,7 +908,7 @@ Proof.
   intros [om Hproto].
   apply protocol_state_project_preloaded_to_preloaded.
   exists om.
-  apply pre_loaded_with_all_messages_protocol_prop in Hproto.
+  apply preloaded_weaken_protocol_prop.
   assumption.
 Qed.
 
@@ -1223,9 +1220,7 @@ We can now finally prove the main result for this section:
     Proof.
       apply (basic_VLSM_incl (machine Xj) (machine PreLoaded))
       ; intros; try (assumption || reflexivity).
-      - destruct H as [_ [[_s Hpm] _]]. exists _s.
-        apply proj_pre_loaded_with_all_messages_protocol_prop.
-        assumption.
+      - apply initial_message_is_protocol; exact I.
       - apply projection_valid_implies_valid.
         destruct H as [_ [_ Hv]].
         assumption.

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -684,10 +684,6 @@ Then <<X1>> is trace-included into <<X2>>.
       intro l; intros. exact I.
     Qed.
 
-(**
-A component [protocol_state]'s [lift_to_composite_state] is a [protocol_state]
-for the [free_composite_vlsm].
-*)
     Lemma protocol_prop_composite_free_lift_generalized_initial
       (P Q : message -> Prop)
       (PimpliesQ : forall m, P m -> Q m)
@@ -746,6 +742,10 @@ for the [free_composite_vlsm].
           apply state_update_twice.
     Qed.
 
+(**
+If @(sj, om)@ has the [protocol_prop]erty for component and @s@ is the [lift_to_composite_state] of @sj@, then
+@(s, om)@ has the [protocol_prop]erty for the [free_composite_vlsm].
+*)
     Lemma protocol_prop_composite_free_lift
       (j : index)
       (sj : vstate (IM j))

--- a/VLSM/Composition.v
+++ b/VLSM/Composition.v
@@ -239,13 +239,20 @@ updating an initial composite state, say [s0], to <<sj>> on component <<j>>.
       - exact output.
     Defined.
 
+    Definition lift_to_composite_finite_trace
+      (j : index)
+      (trj : list (vtransition_item (IM j)))
+      : list (@transition_item _ composite_type)
+      :=
+      List.map (lift_to_composite_transition_item j) trj.
+
     Definition lift_to_composite_trace
       (j : index)
       (trj : vTrace (IM j))
       : @Trace _ composite_type
       :=
       match trj with
-      | Finite s l => Finite (lift_to_composite_state j s) (List.map (lift_to_composite_transition_item j) l)
+      | Finite s l => Finite (lift_to_composite_state j s) (lift_to_composite_finite_trace j l)
       | Infinite s l => Infinite (lift_to_composite_state j s) (Streams.map (lift_to_composite_transition_item j) l)
       end.
 
@@ -353,7 +360,7 @@ the [free_composite_valid]ity.
       inversion Ht. apply state_update_eq.
     Qed.
 
-    Section constraint_subsumption.
+    Section constraint_subsumption_part_one.
 (**
 
 ** Constraint subssumption
@@ -412,100 +419,7 @@ Lemma [basic_VLSM_inclusion]
         apply protocol_generated_valid with _om _s; assumption.
     Qed.
 
-    Lemma constraint_subsumption_can_emit
-      (m : message)
-      (Hm : can_emit X1 m)
-      : can_emit X2 m.
-    Proof.
-      destruct Hm as [(s0,om0) [l [s [Hv1 Ht]]]].
-      assert (Hv2 := constraint_subsumption_protocol_valid _ _ _ Hv1).
-      destruct Hv1 as [[_om0 Hs0] [[_s0 Hom0] Hv1]].
-      apply constraint_subsumption_protocol_prop in Hs0.
-      apply constraint_subsumption_protocol_prop in Hom0.
-      exists (s0, om0). exists l. exists s.
-      destruct Hv2 as [Hv2 Hc2].
-      repeat split; try assumption.
-      - exists _om0. assumption.
-      - exists _s0. assumption.
-    Qed.
-
-    Lemma constraint_subsumption_preloaded_protocol_valid
-      (l : label)
-      (s : state)
-      (om : option message)
-      (Hv : protocol_valid (pre_loaded_with_all_messages_vlsm X1) l (s, om))
-      : vvalid (pre_loaded_with_all_messages_vlsm X2) l (s, om).
-    Proof.
-      destruct Hv as [Hps [Hopm [Hv Hctr]]].
-      split; try assumption.
-      apply Hsubsumption.
-      assumption.
-    Qed.
-
-    Lemma constraint_subsumption_preloaded_protocol_prop
-      (s : state)
-      (om : option message)
-      (Hps : protocol_prop (pre_loaded_with_all_messages_vlsm X1) (s, om))
-      : protocol_prop (pre_loaded_with_all_messages_vlsm X2) (s, om).
-    Proof.
-      induction Hps.
-      - apply (protocol_initial_state (pre_loaded_with_all_messages_vlsm X2) is).
-      - apply (protocol_initial_message (pre_loaded_with_all_messages_vlsm X2)).
-      - apply (protocol_generated (pre_loaded_with_all_messages_vlsm X2)) with _om _s; try assumption.
-        apply constraint_subsumption_preloaded_protocol_valid.
-        destruct Hv as [Hv Hc1].
-        repeat split; try assumption.
-        + exists _om. assumption.
-        + exists _s. assumption.
-    Qed.
-
-    Lemma constraint_subsumption_byzantine_message_prop
-      (m : message)
-      (Hm : byzantine_message_prop X1 m)
-      : byzantine_message_prop X2 m.
-    Proof.
-      destruct Hm as [(s0,om0) [l [s [Hv1 Ht]]]].
-      assert (Hv2 := constraint_subsumption_preloaded_protocol_valid _ _ _ Hv1).
-      destruct Hv1 as [[_om0 Hs0] [[_s0 Hom0] Hv1]].
-      apply constraint_subsumption_preloaded_protocol_prop in Hs0.
-      apply constraint_subsumption_preloaded_protocol_prop in Hom0.
-      exists (s0, om0). exists l. exists s.
-      destruct Hv2 as [Hv2 Hc2].
-      repeat split; try assumption.
-      - exists _om0. assumption.
-      - exists _s0. assumption.
-    Qed.
-
-(* end hide *)
-
-(**
-Then <<X1>> is trace-included into <<X2>>.
-*)
-
-    Lemma constraint_subsumption_incl
-      : VLSM_incl X1 X2.
-    Proof.
-      apply (basic_VLSM_incl (machine X1) (machine X2))
-      ; intros; try (assumption || reflexivity).
-      - destruct H as [_ [[_s Hom] _]]. exists _s.
-        apply constraint_subsumption_protocol_prop.
-        assumption.
-      - apply constraint_subsumption_protocol_valid.
-        assumption.
-    Qed.
-
-    Lemma constraint_subsumption_pre_loaded_with_all_messages_incl
-      : VLSM_incl (pre_loaded_with_all_messages_vlsm X1) (pre_loaded_with_all_messages_vlsm X2).
-    Proof.
-      apply (basic_VLSM_incl (machine (pre_loaded_with_all_messages_vlsm X1)) (machine (pre_loaded_with_all_messages_vlsm X2)))
-      ; intros; try (assumption || reflexivity).
-      - destruct H as [_ [[_s Hom] _]]. exists _s.
-        apply constraint_subsumption_preloaded_protocol_prop. assumption.
-      - apply constraint_subsumption_preloaded_protocol_valid.
-        assumption.
-    Qed.
-
-    End constraint_subsumption.
+    End constraint_subsumption_part_one.
 
 (**
 
@@ -525,18 +439,6 @@ Thus, the [free_composite_vlsm] is the [composite_vlsm] using the
     Definition free_composite_vlsm : VLSM message
       := composite_vlsm free_constraint.
 
-    (** Next two lemmas are corrolaries of the above, instantiates on the
-      free composition whose constraint ([True]) subsumes any constraint.
-    *)
-
-    Lemma constraint_free_incl
-      (constraint : composite_label -> composite_state  * option message -> Prop)
-      : VLSM_incl (composite_vlsm constraint) free_composite_vlsm.
-    Proof.
-      apply constraint_subsumption_incl.
-      intro l; intros. exact I.
-    Qed.
-
     Lemma constraint_free_protocol_prop
       (constraint : composite_label -> composite_state * option message -> Prop)
       (som : state * option message)
@@ -549,23 +451,258 @@ Thus, the [free_composite_vlsm] is the [composite_vlsm] using the
       intro l; intros. exact I.
     Qed.
 
+    Section preloaded_constraint_subsumption.
+
+    Definition preloaded_constraint_subsumption
+        (constraint1 constraint2 : composite_label -> composite_state * option message -> Prop)
+        :=
+        forall (s : composite_state),
+          protocol_state_prop (pre_loaded_with_all_messages_vlsm free_composite_vlsm) s ->
+          forall (l : composite_label) (om : option message),
+            constraint1 l (s, om) -> constraint2 l (s, om).
+    
+    Lemma preloaded_constraint_subsumption_weaker
+        (constraint1 constraint2 : composite_label -> composite_state * option message -> Prop)
+        : constraint_subsumption constraint1 constraint2 -> preloaded_constraint_subsumption constraint1 constraint2.
+    Proof.
+      intros Hcs s Hs l om Hc1.
+      apply Hcs. assumption.
+    Qed.
+
+    Context
+      (constraint1 constraint2 : composite_label -> composite_state * option message -> Prop)
+      (Hsubsumption : preloaded_constraint_subsumption constraint1 constraint2)
+      (X1 := composite_vlsm constraint1)
+      (X2 := composite_vlsm constraint2)
+      .
+
+    Lemma preloaded_constraint_subsumption_protocol_valid
+      (l : label)
+      (s : state)
+      (om : option message)
+      (Hv : protocol_valid X1 l (s, om))
+      : vvalid X2 l (s, om).
+    Proof.
+      destruct Hv as [Hps [Hopm [Hv Hctr]]].
+      split; try assumption.
+      apply Hsubsumption; [|assumption].
+      destruct Hps as [_om Hps].
+      exists _om. apply preloaded_weaken_protocol_prop.
+      apply constraint_free_protocol_prop with constraint1.
+      assumption.
+    Qed.
+
+    Lemma preloaded_constraint_subsumption_protocol_prop
+      (s : state)
+      (om : option message)
+      (Hps : protocol_prop X1 (s, om))
+      : protocol_prop X2 (s, om).
+    Proof.
+      induction Hps.
+      - apply (protocol_initial_state X2 is).
+      - apply (protocol_initial_message X2).
+      - apply (protocol_generated X2) with _om _s; try assumption.
+        apply preloaded_constraint_subsumption_protocol_valid.
+        apply protocol_generated_valid with _om _s; assumption.
+    Qed.
+
+    Lemma preloaded_constraint_subsumption_can_emit
+      (m : message)
+      (Hm : can_emit X1 m)
+      : can_emit X2 m.
+    Proof.
+      destruct Hm as [(s0,om0) [l [s [Hv1 Ht]]]].
+      assert (Hv2 := preloaded_constraint_subsumption_protocol_valid _ _ _ Hv1).
+      destruct Hv1 as [[_om0 Hs0] [[_s0 Hom0] Hv1]].
+      apply preloaded_constraint_subsumption_protocol_prop in Hs0.
+      apply preloaded_constraint_subsumption_protocol_prop in Hom0.
+      exists (s0, om0). exists l. exists s.
+      destruct Hv2 as [Hv2 Hc2].
+      repeat split; try assumption.
+      - exists _om0. assumption.
+      - exists _s0. assumption.
+    Qed.
+
+    Lemma preloaded_constraint_subsumption_preloaded_protocol_valid
+      (l : label)
+      (s : state)
+      (om : option message)
+      (Hv : protocol_valid (pre_loaded_with_all_messages_vlsm X1) l (s, om))
+      : vvalid (pre_loaded_with_all_messages_vlsm X2) l (s, om).
+    Proof.
+      destruct Hv as [Hps [Hopm [Hv Hctr]]].
+      split; [assumption|].
+      apply Hsubsumption; [|assumption].
+      clear -Hps.
+      apply preloaded_protocol_state_prop_iff in Hps.
+      apply preloaded_protocol_state_prop_iff.
+      induction Hps; [constructor; assumption|].
+      apply (preloaded_protocol_generated free_composite_vlsm); [assumption|].
+      split; [apply Hv|exact I].
+    Qed.
+
+    Lemma preloaded_constraint_subsumption_preloaded_protocol_prop
+      (s : state)
+      (om : option message)
+      (Hps : protocol_prop (pre_loaded_with_all_messages_vlsm X1) (s, om))
+      : protocol_prop (pre_loaded_with_all_messages_vlsm X2) (s, om).
+    Proof.
+      induction Hps.
+      - apply (protocol_initial_state (pre_loaded_with_all_messages_vlsm X2) is).
+      - apply (protocol_initial_message (pre_loaded_with_all_messages_vlsm X2)).
+      - apply (protocol_generated (pre_loaded_with_all_messages_vlsm X2)) with _om _s; try assumption.
+        apply preloaded_constraint_subsumption_preloaded_protocol_valid.
+        destruct Hv as [Hv Hc1].
+        repeat split; try assumption.
+        + exists _om. assumption.
+        + exists _s. assumption.
+    Qed.
+
+    Lemma preloaded_constraint_subsumption_byzantine_message_prop
+      (m : message)
+      (Hm : byzantine_message_prop X1 m)
+      : byzantine_message_prop X2 m.
+    Proof.
+      destruct Hm as [(s0,om0) [l [s [Hv1 Ht]]]].
+      assert (Hv2 := preloaded_constraint_subsumption_preloaded_protocol_valid _ _ _ Hv1).
+      destruct Hv1 as [[_om0 Hs0] [[_s0 Hom0] Hv1]].
+      apply preloaded_constraint_subsumption_preloaded_protocol_prop in Hs0.
+      apply preloaded_constraint_subsumption_preloaded_protocol_prop in Hom0.
+      exists (s0, om0). exists l. exists s.
+      destruct Hv2 as [Hv2 Hc2].
+      repeat split; try assumption.
+      - exists _om0. assumption.
+      - exists _s0. assumption.
+    Qed.
+
+(* end hide *)
+
+(**
+Then <<X1>> is trace-included into <<X2>>.
+*)
+
+    Lemma preloaded_constraint_subsumption_incl
+      : VLSM_incl X1 X2.
+    Proof.
+      apply (basic_VLSM_incl (machine X1) (machine X2))
+      ; intros; try (assumption || reflexivity).
+      - destruct H as [_ [[_s Hom] _]]. exists _s.
+        apply preloaded_constraint_subsumption_protocol_prop.
+        assumption.
+      - apply preloaded_constraint_subsumption_protocol_valid.
+        assumption.
+    Qed.
+
+    Lemma preloaded_constraint_subsumption_pre_loaded_with_all_messages_incl
+      : VLSM_incl (pre_loaded_with_all_messages_vlsm X1) (pre_loaded_with_all_messages_vlsm X2).
+    Proof.
+      apply (basic_VLSM_incl (machine (pre_loaded_with_all_messages_vlsm X1)) (machine (pre_loaded_with_all_messages_vlsm X2)))
+      ; intros; try (assumption || reflexivity).
+      - destruct H as [_ [[_s Hom] _]]. exists _s.
+        apply preloaded_constraint_subsumption_preloaded_protocol_prop. assumption.
+      - apply preloaded_constraint_subsumption_preloaded_protocol_valid.
+        assumption.
+    Qed.
+
+    End preloaded_constraint_subsumption.
+
+    Section constraint_subsumption_part_two.
+
+    Context
+      (constraint1 constraint2 : composite_label -> composite_state * option message -> Prop)
+      (Hsubsumption : constraint_subsumption constraint1 constraint2)
+      (X1 := composite_vlsm constraint1)
+      (X2 := composite_vlsm constraint2)
+      .
+
+    Lemma constraint_subsumption_can_emit
+      (m : message)
+      (Hm : can_emit X1 m)
+      : can_emit X2 m.
+    Proof.
+      apply preloaded_constraint_subsumption_can_emit with constraint1 ; [|assumption].
+      apply preloaded_constraint_subsumption_weaker. assumption.
+    Qed.
+
+    Lemma constraint_subsumption_preloaded_protocol_valid
+      (l : label)
+      (s : state)
+      (om : option message)
+      (Hv : protocol_valid (pre_loaded_with_all_messages_vlsm X1) l (s, om))
+      : vvalid (pre_loaded_with_all_messages_vlsm X2) l (s, om).
+    Proof.
+      apply preloaded_constraint_subsumption_preloaded_protocol_valid; [|assumption].
+      apply preloaded_constraint_subsumption_weaker. assumption.
+    Qed.
+
+    Lemma constraint_subsumption_preloaded_protocol_prop
+      (s : state)
+      (om : option message)
+      (Hps : protocol_prop (pre_loaded_with_all_messages_vlsm X1) (s, om))
+      : protocol_prop (pre_loaded_with_all_messages_vlsm X2) (s, om).
+    Proof.
+      apply preloaded_constraint_subsumption_preloaded_protocol_prop; [|assumption].
+      apply preloaded_constraint_subsumption_weaker. assumption.
+    Qed.
+
+    Lemma constraint_subsumption_byzantine_message_prop
+      (m : message)
+      (Hm : byzantine_message_prop X1 m)
+      : byzantine_message_prop X2 m.
+    Proof.
+      apply preloaded_constraint_subsumption_byzantine_message_prop with constraint1; [|assumption].
+      apply preloaded_constraint_subsumption_weaker. assumption.
+    Qed.
+
+(* end hide *)
+
+(**
+Then <<X1>> is trace-included into <<X2>>.
+*)
+
+    Lemma constraint_subsumption_incl
+      : VLSM_incl X1 X2.
+    Proof.
+      apply preloaded_constraint_subsumption_incl.
+      apply preloaded_constraint_subsumption_weaker. assumption.
+    Qed.
+
+    Lemma constraint_subsumption_pre_loaded_with_all_messages_incl
+      : VLSM_incl (pre_loaded_with_all_messages_vlsm X1) (pre_loaded_with_all_messages_vlsm X2).
+    Proof.
+      apply preloaded_constraint_subsumption_pre_loaded_with_all_messages_incl.
+      apply preloaded_constraint_subsumption_weaker. assumption.
+    Qed.
+
+    End constraint_subsumption_part_two.
+
+    Lemma constraint_free_incl
+      (constraint : composite_label -> composite_state  * option message -> Prop)
+      : VLSM_incl (composite_vlsm constraint) free_composite_vlsm.
+    Proof.
+      apply constraint_subsumption_incl.
+      intro l; intros. exact I.
+    Qed.
+
 (**
 A component [protocol_state]'s [lift_to_composite_state] is a [protocol_state]
 for the [free_composite_vlsm].
 *)
-    Lemma protocol_prop_composite_free_lift
+    Lemma protocol_prop_composite_free_lift_generalized_initial
+      (P Q : message -> Prop)
+      (PimpliesQ : forall m, P m -> Q m)
       (j : index)
       (sj : vstate (IM j))
       (om : option message)
-      (Hp : protocol_prop (IM j) (sj, om))
+      (Hp : protocol_prop (vlsm_add_initial_messages (IM j) P) (sj, om))
       (s := lift_to_composite_state j sj)
-      : protocol_prop free_composite_vlsm (s, om).
+      : protocol_prop (vlsm_add_initial_messages free_composite_vlsm Q) (s, om).
     Proof.
       remember (sj, om) as sjom.
       generalize dependent om. generalize dependent sj.
       induction Hp; intros; inversion Heqsjom; subst; clear Heqsjom
       ; unfold s0; clear s0.
-      - assert (Hinit : vinitial_state_prop free_composite_vlsm (lift_to_composite_state j s)).
+      - assert (Hinit : vinitial_state_prop (vlsm_add_initial_messages free_composite_vlsm Q) (lift_to_composite_state j s)).
         { intro i. unfold lift_to_composite_state.
           destruct (decide (i = j)).
           - subst; rewrite state_update_eq. unfold s. destruct is. assumption.
@@ -575,66 +712,77 @@ for the [free_composite_vlsm].
             simpl.
             apply Hinit.
         }
-        remember (exist (vinitial_state_prop free_composite_vlsm) (lift_to_composite_state j s) Hinit) as six.
-        replace (lift_to_composite_state j s) with (proj1_sig six); try (subst; reflexivity).
-        apply (protocol_initial_state free_composite_vlsm).
-      - assert (Hinit : vinitial_message_prop free_composite_vlsm (proj1_sig im)).
-        { exists j. exists im. reflexivity. }
-        replace (lift_to_composite_state j s) with (proj1_sig (vs0 free_composite_vlsm))
-        ; try (symmetry; apply state_update_id; reflexivity).
-        unfold om in *; unfold s in *; clear s om.
-        destruct im as [m _H]; simpl in *; clear _H.
-        remember (exist (vinitial_message_prop free_composite_vlsm) m Hinit) as im.
-        replace m with (proj1_sig im); try (subst; reflexivity).
-        apply (protocol_initial_message free_composite_vlsm).
+        remember (exist _ _ Hinit) as six.
+        replace (lift_to_composite_state j s) with (proj1_sig six) by (subst; reflexivity).
+        apply (protocol_initial_state (vlsm_add_initial_messages free_composite_vlsm Q)).
+      -
+        destruct im as [m Hjm]; simpl in om.
+        cut (vinitial_message_prop (vlsm_add_initial_messages free_composite_vlsm Q) m).
+        { intro Hinit. 
+          replace (lift_to_composite_state j s) with (proj1_sig (vs0 (vlsm_add_initial_messages free_composite_vlsm Q)))
+          ; try (symmetry; apply state_update_id; reflexivity).
+          unfold om. clear om.
+          change m with (proj1_sig (exist _ m Hinit)).
+          apply protocol_initial_message.
+        }
+        destruct Hjm as [Hjm | HPm]; [|right; apply PimpliesQ; assumption].
+        left. exists j. exists (exist _ m Hjm). reflexivity.
       - specialize (IHHp1 s _om eq_refl).
         specialize (IHHp2 _s om eq_refl).
         replace
           (@pair composite_state (option message) (lift_to_composite_state j sj) om0)
           with
-          (vtransition free_composite_vlsm (existT _ j l) (lift_to_composite_state j s, om)).
-        + apply (protocol_generated free_composite_vlsm) with _om (lift_to_composite_state j _s)
-          ; try assumption.
-          split; try exact I.
+          (vtransition (vlsm_add_initial_messages free_composite_vlsm Q) (existT _ j l) (lift_to_composite_state j s, om)).
+        + apply (protocol_generated (vlsm_add_initial_messages free_composite_vlsm Q)) with _om (lift_to_composite_state j _s)
+          ; [assumption | assumption|].
+          split; [|exact I].
           simpl. unfold lift_to_composite_state. rewrite state_update_eq. assumption.
         + unfold vtransition. simpl. unfold lift_to_composite_state.
           rewrite state_update_eq. unfold vtransition.
-          replace (@transition message
-          (@projT1 (VLSM_type message)
-             (fun T : VLSM_type message =>
-              @sigT (@VLSM_sign message T)
-                (fun S : @VLSM_sign message T => @VLSM_class message T S))
-             (IM j))
-          (@projT1
-             (@VLSM_sign message
-                (@projT1 (VLSM_type message)
-                   (fun T : VLSM_type message =>
-                    @sigT (@VLSM_sign message T)
-                      (fun S : @VLSM_sign message T => @VLSM_class message T S))
-                   (IM j)))
-             (fun
-                S : @VLSM_sign message
-                      (@projT1 (VLSM_type message)
-                         (fun T : VLSM_type message =>
-                          @sigT (@VLSM_sign message T)
-                            (fun S : @VLSM_sign message T =>
-                             @VLSM_class message T S))
-                         (IM j)) =>
-              @VLSM_class message
-                (@projT1 (VLSM_type message)
-                   (fun T : VLSM_type message =>
-                    @sigT (@VLSM_sign message T)
-                      (fun S0 : @VLSM_sign message T => @VLSM_class message T S0))
-                   (IM j)) S)
-             (@projT2 (VLSM_type message)
-                (fun T : VLSM_type message =>
-                 @sigT (@VLSM_sign message T)
-                   (fun S : @VLSM_sign message T => @VLSM_class message T S))
-                (IM j))) (@machine message (IM j)) l
-          (@pair (@vstate message (IM j)) (option message) s om))
-          with (sj, om0).
+          match goal with
+          |- (let (_, _) := ?t in _) = _ => replace t with (sj, om0)
+          end.
           f_equal.
           apply state_update_twice.
+    Qed.
+
+    Lemma protocol_prop_composite_free_lift
+      (j : index)
+      (sj : vstate (IM j))
+      (om : option message)
+      (Hp : protocol_prop (IM j) (sj, om))
+      (s := lift_to_composite_state j sj)
+      : protocol_prop free_composite_vlsm (s, om).
+    Proof.
+      apply vlsm_is_add_initial_False_protocol_prop.
+      apply vlsm_is_add_initial_False_protocol_prop in Hp.
+      remember (fun _ : message => False) as P.
+      apply (protocol_prop_composite_free_lift_generalized_initial P P); [|assumption].
+      intro m. exact id.
+    Qed.
+
+    Lemma can_emit_composite_free_lift
+      (P Q : message -> Prop)
+      (PimpliesQ : forall m, P m -> Q m)
+      (j : index)
+      (m : message)
+      (Htrj : can_emit (vlsm_add_initial_messages (IM j) P) m)
+      : can_emit (vlsm_add_initial_messages free_composite_vlsm Q) m.
+    Proof.
+      destruct Htrj as [(s,om) [l [s' [[[_om Hs] [[_s Hom] Hv]] Ht]]]].
+      exists ((lift_to_composite_state j s), om).
+      exists (existT _ j l).
+      exists (lift_to_composite_state j s').
+      apply (protocol_prop_composite_free_lift_generalized_initial _ _ PimpliesQ) in Hs.
+      apply (protocol_prop_composite_free_lift_generalized_initial _ _ PimpliesQ) in Hom.
+      repeat split; [exists _om;assumption| exists (lift_to_composite_state j _s); assumption| ..].
+      - simpl. unfold lift_to_composite_state. rewrite state_update_eq. assumption.
+      - unfold lift_to_composite_state. simpl. rewrite state_update_eq.
+        match goal with
+        |- (let (_, _) := ?t in _) = _ => replace t with (s', Some m)
+        end.
+        f_equal.
+        apply state_update_twice.
     Qed.
 
     (** Updating a composite initial state with a component initial state
@@ -690,7 +838,6 @@ for the [free_composite_vlsm].
           rewrite Htj in Hgen.
           eexists _. apply Hgen.
     Qed.
-
   End composite_vlsm.
 
 End VLSM_composition.

--- a/VLSM/Equivocation.v
+++ b/VLSM/Equivocation.v
@@ -1101,6 +1101,16 @@ Proof.
   apply proper_not_received.
 Defined.
 
+Lemma has_been_received_step_update
+      `(Hhbs: has_been_received_capability message vlsm):
+  forall l s im s' om,
+    protocol_transition (pre_loaded_with_all_messages_vlsm vlsm) l (s,im) (s',om) ->
+    forall m,
+      has_been_received vlsm s' m <-> (im = Some m \/ has_been_received vlsm s m).
+Proof.
+  exact (oracle_step_update (has_been_received_stepwise_from_trace Hhbs)).
+Qed.
+
 
 (**
 ** A state message oracle for messages sent or received
@@ -1769,90 +1779,49 @@ Context
   {Hbr : has_been_received_capability X}
   .
 
-Record cannot_resend_message_stepwise_props
-  : Prop :=
-{cannot_resend_simultaneously: 
-  forall l s m s' om,
-    protocol_transition (pre_loaded_with_all_messages_vlsm X) l (s,Some m) (s',om) ->
-    om <> Some m
-;
-cannot_resend_update:
-  forall l s im s' om,
-    protocol_transition (pre_loaded_with_all_messages_vlsm X) l (s,im) (s',om) ->
-    forall m, has_been_received X s m -> ~ has_been_sent X s m ->
-      ~has_been_sent X s' m
-}.
 
-Definition cannot_resend_message_prop
-  : Prop :=
-  forall
-    (is : state)
-    (tr1 tr2 : list transition_item)
-    (Htr : finite_protocol_trace PreX is (tr1 ++ tr2))
-    (s1 := last (List.map destination tr1) is)
-    (s2 := last (List.map destination (tr1 ++ tr2)) is)
-    (m : message)
-    (Hrm : has_been_received X s1 m),
-    ~has_been_sent X s1 m -> ~has_been_sent X s2 m.
+Definition cannot_resend_message_stepwise_prop : Prop :=
+  forall l s oim s' m,
+    protocol_transition (pre_loaded_with_all_messages_vlsm X) l (s,oim) (s',Some m) ->
+    ~has_been_sent X s m /\ ~has_been_received X s' m.
 
-Lemma cannot_resend_message_stepwise_prop_iff
-  : cannot_resend_message_prop <-> 
-    forall l s im s' om
-      (Ht : protocol_transition (pre_loaded_with_all_messages_vlsm X) l (s,im) (s',om)),
-      forall m (Hr : has_been_received X s m),
-        ~ has_been_sent X s m -> ~has_been_sent X s' m.
+Lemma cannot_resend_received_message_in_future
+  (Hno_resend : cannot_resend_message_stepwise_prop)
+  (s1 s2 : state)
+  (Hfuture : in_futures PreX s1 s2)
+  (m : message)
+  (Hreceived_not_previously_sent : has_been_received X s1 m /\ ~has_been_sent X s1 m)
+  : has_been_received X s2 m /\ ~has_been_sent X s2 m.
 Proof.
-  split; intros; intro; intros.
-  - pose proof (protocol_transition_origin _ Ht) as [_om Hs].
-    pose proof (protocol_transition_destination _ Ht) as Hs'.
-    specialize (protocol_is_trace PreX _ _ Hs) as [Hinit | [is [tr1 [Htr1 [Hlsts Hlstm]]]]].
-    + destruct (has_been_received_stepwise_from_trace Hbr) .
-      apply oracle_no_inits0 with (m := m) in Hinit. elim Hinit. assumption.
-    + assert (Hx : finite_protocol_trace_from PreX s [{| l := l; input := im; destination := s'; output := om |}]).
-      { constructor; [constructor|assumption]. assumption. }
-      apply last_error_destination_last with (default := is) in Hlsts.
-      rewrite <- Hlsts in Hx.
-      match type of Hx with
-      | context [[?i]] => remember i as item
-      end.
-      specialize (finite_protocol_trace_from_app_iff PreX is tr1 [item]) as Happ.
-      apply proj1 in Happ.
-      specialize (Happ (conj (proj1 Htr1) Hx)).
-      specialize (H _ _ _ (conj Happ (proj2 Htr1))).
-      subst s.
-      spec H m Hr H0.
-      rewrite map_app in H. simpl in H. rewrite last_is_last in H.
-      subst item. elim H. assumption.
-  - induction tr2 using rev_ind; [unfold s2; rewrite app_nil_r; assumption|].
-    destruct Htr as [Htr Hinit]. rewrite app_assoc in Htr.
-    apply finite_protocol_trace_from_app_iff in Htr.
-    destruct Htr as [Htr Hx].
-    specialize (IHtr2 (conj Htr Hinit)).
-    inversion Hx. subst. clear Hx H4.
-    unfold s2. clear s2. rewrite app_assoc. rewrite map_app. simpl. rewrite last_is_last.
-    simpl in *.
-    match type of IHtr2 with
-    | ~ has_been_sent _ ?l _ => remember l as s'
-    end.
-    specialize (H _ _ _ _ _ H5 m).
-    apply H; [|assumption].
-    clear - Htr Hrm Heqs'.
-    apply (finite_protocol_trace_from_app_iff PreX) in Htr.
-    rewrite map_app in Heqs'. rewrite last_app in Heqs'.
-    destruct Htr as [_ Htr].
-    subst. unfold s1 in *. simpl in *. clear s1.
-    match type of Hrm with
-    | has_been_received _ ?l _ => remember l as s
-    end.
-    clear Heqs.
-    apply in_futures_preserving_oracle_from_stepwise with (field_selector input) s.
-    + apply has_been_received_stepwise_from_trace.
-    + exists tr2. split; [assumption|reflexivity].
-    + assumption.
+  destruct Hfuture as [tr2 [Htr2 Hs2]].
+  apply finite_protocol_trace_from_complete_left in Htr2.
+  destruct Htr2 as [is [tr1 [Htr Hs1]]].
+  generalize dependent s2. induction tr2 using rev_ind; intros; [subst s2; assumption|].
+  clear Hreceived_not_previously_sent.
+  destruct Htr as [Htr Hinit]. rewrite app_assoc in Htr.
+  apply finite_protocol_trace_from_app_iff in Htr.
+  destruct Htr as [Htr Hx].
+  specialize (IHtr2 (conj Htr Hinit) _ eq_refl).
+  inversion Hx. subst. clear Hx H2.
+  rewrite! map_app. simpl. rewrite last_is_last.
+  rewrite map_app in H3. rewrite last_app in H3. simpl in *.
+  match type of IHtr2 with
+  | has_been_received _ ?l _ /\ _ => remember l as s'
+  end.
+  clear Heqs'.
+  destruct IHtr2 as [Hbr1 Hnbs1].
+  specialize (has_been_received_step_update _ _ _ _ _ _ H3 m) as Hrupd.
+  specialize (has_been_sent_step_update _ _ _ _ _ _ H3 m) as Hsupd.
+  split.
+  - apply Hrupd. right. assumption.
+  - intro contra. apply Hsupd in contra.
+    destruct contra as [contra|contra]; [| contradiction].
+    subst. apply Hno_resend in H3.
+    destruct H3 as [_ Hnr]. elim Hnr. apply Hrupd. right. assumption.
 Qed.
 
   Context
-    (Hno_resend : cannot_resend_message_stepwise_props).
+    (Hno_resend : cannot_resend_message_stepwise_prop).
 
   Lemma lift_preloaded_trace_to_seeded
     (P Q : message -> Prop)
@@ -1884,28 +1853,17 @@ Qed.
         | finite_protocol_trace_from _ ?l _ => remember l as s
         end.
         inversion Hx. subst s' tl. clear Hx H5.
-        pose proof (protocol_transition_origin PreX H6) as Hs.
-        specialize (cannot_resend_update Hno_resend _ _ _ _ _ H6 m') as Hnrs.
-        symmetry in Heqs.
-        spec Hnrs.
-        { apply proper_received; [assumption|].
-          apply has_been_received_consistency; [assumption|assumption|].
-          exists is,tr,(conj Htr Hinit). split; assumption.
-        }
-        spec Hnrs.
-        { intro Hcontras. elim H0.
-          apply proper_sent in Hcontras; [|assumption].
-          specialize (Hcontras _ _ (conj Htr Hinit)).
-          apply Hcontras. assumption.
-        }
+        pose proof (protocol_transition_destination PreX H6) as Hs.
+        rewrite <- H1 in H2. simpl in H2. subst oom.
+        specialize (Hno_resend _ _ _ _ _ H6) as Hnrs.
+        destruct Hnrs as [_ Hnrs].
         elim Hnrs.
-        pose proof (protocol_transition_destination PreX H6) as Hs0.
-        apply proper_sent; [assumption|].
-        apply has_been_sent_consistency; [assumption|assumption|].
-        exists is, (tr ++ [x]), Htr'.
-        split.
-        + rewrite map_app. simpl. rewrite last_is_last. subst. reflexivity.
-        + apply Exists_app. right. assumption.
+        apply proper_received; [assumption|].
+        apply has_been_received_consistency; [assumption|assumption|].
+        exists is,(tr ++ [x]),Htr'.
+        rewrite map_app. simpl. rewrite last_is_last.
+        split; [subst; reflexivity|].
+        apply Exists_app. left. assumption.
       }
       apply (finite_protocol_trace_from_app_iff ((vlsm_add_initial_messages X Q) )).
       split; [assumption|].
@@ -1934,8 +1892,17 @@ Qed.
         * apply Exists_app in e.
           destruct e as [e|e]; [apply (protocol_trace_output_is_protocol _ _ _ IHtr _ e)|].
           inversion e; [|inversion H1]. subst x0 l0.
-          apply (cannot_resend_simultaneously Hno_resend) in H3.
-          subst x. simpl in H1. congruence.
+          rewrite <- H in H1. simpl in H1. subst oom.
+          pose proof (protocol_transition_destination PreX H3) as Hs.
+          apply Hno_resend in H3.
+          destruct H3 as [_ Hnrs].
+          elim Hnrs.
+          apply proper_received; [assumption|].
+          apply has_been_received_consistency; [assumption|assumption|].
+          exists is,(tr ++ [x]),Htr'.
+          rewrite map_app. simpl. rewrite last_is_last.
+          split; [subst; reflexivity|].
+          apply Exists_app. right. constructor. subst. reflexivity.
         * spec Htrm n.
           apply protocol_message_prop_iff. left.
           cut (vinitial_message_prop ((vlsm_add_initial_messages X Q)) m).
@@ -1963,7 +1930,7 @@ Section full_node_constraint.
           (X_has_been_observed_capability : has_been_observed_capability X := has_been_observed_capability_from_sent_received X)
           (admissible_index : composite_state IM -> index -> Prop)
           (** admissible equivocator index: this index can equivocate from given state *)
-          (Hno_resend : forall i : index, cannot_resend_message_stepwise_props (IM i))
+          (Hno_resend : forall i : index, cannot_resend_message_stepwise_prop (IM i))
           .
 
   Existing Instance X_has_been_observed_capability.
@@ -1979,7 +1946,7 @@ Section full_node_constraint.
       exists m, om = Some m /\
       exists (i : index), admissible_index s i /\
       exists (si : vstate (IM i)),
-          can_emit_in_state (pre_loaded_with_all_messages_vlsm (IM i)) si m /\
+          protocol_generated_prop (pre_loaded_with_all_messages_vlsm (IM i)) si m /\
           forall (m' : message),
             has_been_received (IM i) si m' ->
             has_not_been_sent (IM i) si m' ->
@@ -2009,8 +1976,8 @@ Section full_node_constraint.
       has_been_received (IM i) si m' ->
       has_not_been_sent (IM i) si m' ->
       no_additional_equivocations X s m')
-    (Hsim: can_emit_in_state (pre_loaded_with_all_messages_vlsm (IM i)) si m)
-    : can_emit_in_state
+    (Hsim: protocol_generated_prop (pre_loaded_with_all_messages_vlsm (IM i)) si m)
+    : protocol_generated_prop
       (vlsm_add_initial_messages (IM i) (no_additional_equivocations X s))
       si m.
   Proof.

--- a/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -143,7 +143,7 @@ Section fixed_equivocation_with_fullnode.
     (finite_index : Listing index_listing)
     (equivocating : set index)
     (admissible_index := fun s i => In i equivocating)
-    (Hno_resend : forall i : index, cannot_resend_message_stepwise_props (IM i))
+    (Hno_resend : forall i : index, cannot_resend_message_stepwise_prop (IM i))
     (full_node_constraint
       := full_node_condition_for_admissible_equivocators IM Hbs Hbr finite_index admissible_index)
     (full_node_constraint_alt

--- a/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
+++ b/VLSM/Equivocators/Composition/LimitedEquivocation/FixedEquivocation.v
@@ -18,13 +18,13 @@ Section equivocators_fixed_equivocations_vlsm.
 
 Context
   {message : Type}
-  (index : Type)
+  {index : Type}
   {IndEqDec : EqDecision index}
   (IM : index -> VLSM message)
   (Hbs : forall i : index, has_been_sent_capability (IM i))
   {i0 : Inhabited index}
   (equivocator_IM := equivocator_IM IM)
-  (index_listing : list index)
+  {index_listing : list index}
   (finite_index : Listing index_listing)
   (equivocating : set index)
   .
@@ -46,15 +46,20 @@ End equivocators_fixed_equivocations_vlsm.
 
 Section fixed_equivocation_without_fullnode.
 
-Context {message : Type}
-  (index : Type)
+Context
+  {message : Type}
+  {index : Type}
   {IndEqDec : EqDecision index}
   (IM : index -> VLSM message)
   (Hbs : forall i : index, has_been_sent_capability (IM i))
+  (Hbr : forall i : index, has_been_received_capability (IM i))
   {i0 : Inhabited index}
   (X := free_composite_vlsm IM)
-  (index_listing : list index)
+  {index_listing : list index}
   (finite_index : Listing index_listing)
+  (X_has_been_sent_capability : has_been_sent_capability X := composite_has_been_sent_capability IM (free_constraint IM) finite_index Hbs)
+  (X_has_been_received_capability : has_been_received_capability X := composite_has_been_received_capability IM (free_constraint IM) finite_index Hbr)
+  (X_has_been_observed_capability : has_been_observed_capability X := has_been_observed_capability_from_sent_received X)
   (equivocators_choice := equivocators_choice IM)
   (equivocators_state_project := equivocators_state_project IM)
   (equivocator_IM := equivocator_IM IM)
@@ -63,6 +68,8 @@ Context {message : Type}
   (equivocating : set index)
   (Hi0_equiv : equivocating <> [])
   .
+
+Existing Instance X_has_been_observed_capability.
 
 Definition index_equivocating_prop (i : index) : Prop := In i equivocating.
 
@@ -98,48 +105,115 @@ Definition equivocating_IM
 Definition free_equivocating_vlsm_composition : VLSM message
   := free_composite_vlsm equivocating_IM.
 
-Definition sent_by_non_equivocating
-  (s : composite_state IM)
-  (m : message)
-  : Prop
-  :=
-  exists
-    (i : index)
-    (Hi : ~In i equivocating),
-    has_been_sent (IM i) (s i) m.
-
 Definition seeded_free_equivocators_composition
   (messageSet : message -> Prop)
-  := vlsm_add_initial_messages free_equivocating_vlsm_composition messageSet.
+  := vlsm_add_initial_messages free_equivocating_vlsm_composition
+      (fun m => messageSet m \/ vinitial_message_prop X m).
 
-  Context
-    {validator : Type}
-    (A : validator -> index)
-    (sender : message -> option validator)
-    (Hsender_safety : Prop := sender_safety_prop IM (free_constraint IM) A sender)
-    .
+Context
+  {validator : Type}
+  .
 
 Definition fixed_equivocation_constraint
   (l : composite_label IM)
   (som : composite_state IM * option message)
   : Prop
   :=
+  no_additional_equivocations_constraint X l som \/
   let (s, om) := som in
-  match om with
-  | None => True
-  | Some m =>
-    let ov := sender m in
-    match ov with
-    | None => composite_initial_message_prop IM m
-    | Some v =>
-      let i := A v in
-      if index_equivocating_prop_dec i
-      then protocol_message_prop (seeded_free_equivocators_composition (sent_by_non_equivocating s)) m
-      else has_been_sent (IM i) (s i) m
-    end
-  end.
+  exists m : message, om = Some m /\
+  can_emit (seeded_free_equivocators_composition (no_additional_equivocations X s)) m.
 
 Definition fixed_equivocation_vlsm_composition : VLSM message
   := composite_vlsm IM fixed_equivocation_constraint.
 
 End fixed_equivocation_without_fullnode.
+
+Section fixed_equivocation_with_fullnode.
+  Context
+    {message : Type}
+    (index : Type)
+    {IndEqDec : EqDecision index}
+    (IM : index -> VLSM message)
+    (Hbs : forall i : index, has_been_sent_capability (IM i))
+    (Hbr : forall i : index, has_been_received_capability (IM i))
+    {i0 : Inhabited index}
+    (equivocator_IM := equivocator_IM IM)
+    (index_listing : list index)
+    (finite_index : Listing index_listing)
+    (equivocating : set index)
+    (admissible_index := fun s i => In i equivocating)
+    (Hno_resend : forall i : index, cannot_resend_message_stepwise_props (IM i))
+    (full_node_constraint
+      := full_node_condition_for_admissible_equivocators IM Hbs Hbr finite_index admissible_index)
+    (full_node_constraint_alt
+      := full_node_condition_for_admissible_equivocators_alt IM Hbs Hbr finite_index admissible_index)
+    .
+
+  Section fixed_equivocation_constraint_comparison.
+
+  Context
+    `{EqDecision message}
+    (Hi0_equiv : equivocating <> [])
+    (equivocating_inhabited : Inhabited (equivocating_index equivocating) := equivocating_i0 _ Hi0_equiv)
+    {validator : Type}
+    (A : validator -> index)
+    (sender : message -> option validator)
+    (fixed_equivocation_constraint : composite_label IM  -> composite_state IM * option message -> Prop
+      := fixed_equivocation_constraint IM Hbs Hbr finite_index equivocating Hi0_equiv)
+    (Hsender_safety : Prop := sender_safety_prop IM (free_constraint IM) A sender)
+    (X := free_composite_vlsm IM)
+    (X_has_been_sent_capability : has_been_sent_capability X := composite_has_been_sent_capability IM (free_constraint IM) finite_index Hbs)
+    (X_has_been_received_capability : has_been_received_capability X := composite_has_been_received_capability IM (free_constraint IM) finite_index Hbr)
+    (X_has_been_observed_capability : has_been_observed_capability X := has_been_observed_capability_from_sent_received X)
+    .
+  
+  Local Instance index_equivocating_dec
+    (i : index)
+    : Decision (index_equivocating_prop equivocating i).
+  Proof.
+    apply index_equivocating_prop_dec.
+  Qed.
+
+  Existing Instance  equivocating_inhabited.
+  Existing Instance  equivocating_index_eq_dec.
+
+  Existing Instance X_has_been_observed_capability.
+  Lemma fixed_equivocation_constraint_subsumption :
+    preloaded_constraint_subsumption IM full_node_constraint fixed_equivocation_constraint.
+  Proof.
+    cut (preloaded_constraint_subsumption IM full_node_constraint_alt fixed_equivocation_constraint).
+    {
+      intros H s Hs l om Hfull.
+      apply H; [assumption|].
+      apply
+        (@full_node_condition_for_admissible_equivocators_subsumption
+          _ _ _ _ IM _ Hbs Hbr _ finite_index
+          admissible_index
+          Hno_resend
+        ); [assumption|].
+      assumption.
+    }
+    intros s Hs l om [Hno_equiv | Hfull]; [left; assumption|].
+    destruct Hfull as [m [Hom [i [Hi Hm]]]].
+    subst om.
+    right. exists m. split; [reflexivity|].
+    remember (no_additional_equivocations (free_composite_vlsm IM) s) as P.
+    unfold seeded_free_equivocators_composition.
+    remember (fun m => P m \/ vinitial_message_prop (free_composite_vlsm IM) m) as Q.
+    unfold free_equivocating_vlsm_composition.
+    specialize (can_emit_composite_free_lift (equivocating_IM IM equivocating) P Q) as Hemit.
+    spec Hemit. { intros. subst Q. left. assumption. }
+    assert
+      (Hi_dec :
+        @bool_decide
+          (@index_equivocating_prop index equivocating i)
+          (@index_equivocating_prop_dec index IndEqDec equivocating i) = true).
+    { apply bool_decide_eq_true. assumption. }
+    specialize (Hemit (exist _  i Hi_dec)).
+    apply Hemit.
+    unfold equivocating_IM. simpl. assumption.
+  Qed.
+
+  End fixed_equivocation_constraint_comparison.
+End fixed_equivocation_with_fullnode.

--- a/VLSM/FullNode/Composite/Free.v
+++ b/VLSM/FullNode/Composite/Free.v
@@ -477,8 +477,8 @@ Lemma full_composed_free_sent_messages_comparable
   (Htr : finite_protocol_trace (pre_loaded_with_all_messages_vlsm VLSM_full_composed_free) s tr)
   (m1 m2 : message)
   (Hvalidator : sender m1 = sender m2)
-  (Hm1 : Equivocation.trace_has_message VLSM_full_composed_free (Equivocation.field_selector output) m1 tr)
-  (Hm2 : Equivocation.trace_has_message VLSM_full_composed_free (Equivocation.field_selector output) m2 tr)
+  (Hm1 : Equivocation.trace_has_message VLSM_full_composed_free (field_selector output) m1 tr)
+  (Hm2 : Equivocation.trace_has_message VLSM_full_composed_free (field_selector output) m2 tr)
   : m1 = m2 \/ validator_message_preceeds _ _ m1 m2 \/ validator_message_preceeds _ _ m2 m1.
 Proof.
   unfold Equivocation.trace_has_message in *.

--- a/VLSM/Validating.v
+++ b/VLSM/Validating.v
@@ -144,10 +144,11 @@ Lemma [protocol_message_projection] to show that its conditions are fulfilled.
         : VLSM_incl PreLoaded Xi.
     Proof.
         apply (basic_VLSM_incl (machine PreLoaded) (machine Xi))
-        ; intros; try destruct H as [_ [_ H]]; try (assumption || reflexivity).
+        ; intros; try (assumption || reflexivity).
         - apply Hvalidating in H. destruct H as [_ [_ [_ [Hopm _]]]].
           apply protocol_message_projection. assumption.
-        - apply Hvalidating in H. assumption.
+        - destruct H as [_ [_ H]]. 
+          apply Hvalidating in H. assumption.
     Qed.
 
 (**


### PR DESCRIPTION
Definitions and results used to relate the two full-node-like constraints and the fixed-equivocation-constraint based on the seeded free composition of the equivocating nodes.