### PR TITLE
Dependency graph landing page for proof movies

### DIFF
--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -36,8 +36,8 @@ coq2html: $(GLOBFILES) $(VFILES)
 .PHONY: coq2html
 
 $(ALECTRYONHTMLFILES): %.alectryon.html: %.v %.glob %.vo $(ALECTRYONDIR)/toc.html
-	$(SHOW)'ALECTRYON --output-directory $(ALECTRYONDIR) $<'
-	$(HIDE)$(ALECTRYON) $(ALECTRYONHTMLFLAGS) $(COQDOCLIBS) --output-directory $(ALECTRYONDIR) $<
+	$(SHOW)'ALECTRYON --output $(ALECTRYONDIR)/$(addsuffix .html,$(addprefix CasperCBC.,$(subst /,.,$(basename $<))))'
+	$(HIDE)$(ALECTRYON) $(ALECTRYONHTMLFLAGS) $(COQDOCLIBS) --output $(ALECTRYONDIR)/$(addsuffix .html,$(addprefix CasperCBC.,$(subst /,.,$(basename $<)))) $<
 .PHONY: $(ALECTRYONHTMLFILES)
 
 alectryon: $(ALECTRYONHTMLFILES)
@@ -46,7 +46,7 @@ alectryon: $(ALECTRYONHTMLFILES)
 $(ALECTRYONDIR)/toc.html:
 	$(HIDE)mkdir -p $(@D)
 	$(HIDE)cat resources/alectryon_toc_header.html > $@
-	$(HIDE)for vfile in $(notdir $(basename $(VFILES))) ; do \
+	$(HIDE)for vfile in $(addprefix CasperCBC.,$(subst /,.,$(basename $(VFILES)))) ; do \
 	    echo "    <li><a href='$$vfile.html'>$$vfile</a></li>" >> $@; \
 	done
 	$(HIDE)cat resources/alectryon_toc_footer.html >> $@

--- a/Makefile.coq.local
+++ b/Makefile.coq.local
@@ -35,9 +35,9 @@ coq2html: $(GLOBFILES) $(VFILES)
 	$(HIDE)cd VLSM && $(COQ2HTML) -base CasperCBC.VLSM -d ../$(COQ2HTMLDIR) *.v *.glob
 .PHONY: coq2html
 
-$(ALECTRYONHTMLFILES): %.alectryon.html: %.v %.glob %.vo $(ALECTRYONDIR)/toc.html
-	$(SHOW)'ALECTRYON --output $(ALECTRYONDIR)/$(addsuffix .html,$(addprefix CasperCBC.,$(subst /,.,$(basename $<))))'
-	$(HIDE)$(ALECTRYON) $(ALECTRYONHTMLFLAGS) $(COQDOCLIBS) --output $(ALECTRYONDIR)/$(addsuffix .html,$(addprefix CasperCBC.,$(subst /,.,$(basename $<)))) $<
+$(ALECTRYONHTMLFILES): %.alectryon.html: %.v %.glob %.vo $(ALECTRYONDIR)/toc.html $(ALECTRYONDIR)/map.html $(ALECTRYONDIR)/deps.png
+	$(SHOW)'ALECTRYON --output-directory $(ALECTRYONDIR) --output $(ALECTRYONDIR)/$(addsuffix .html,$(addprefix CasperCBC.,$(subst /,.,$(basename $<))))'
+	$(HIDE)$(ALECTRYON) $(ALECTRYONHTMLFLAGS) $(COQDOCLIBS) --output-directory $(ALECTRYONDIR) --output $(ALECTRYONDIR)/$(addsuffix .html,$(addprefix CasperCBC.,$(subst /,.,$(basename $<)))) $<
 .PHONY: $(ALECTRYONHTMLFILES)
 
 alectryon: $(ALECTRYONHTMLFILES)
@@ -50,6 +50,14 @@ $(ALECTRYONDIR)/toc.html:
 	    echo "    <li><a href='$$vfile.html'>$$vfile</a></li>" >> $@; \
 	done
 	$(HIDE)cat resources/alectryon_toc_footer.html >> $@
+
+$(ALECTRYONDIR)/map.html: deps.map
+	$(HIDE)mkdir -p $(@D)
+	sed -e '/#include deps.map/r deps.map' resources/map_template.html > $(ALECTRYONDIR)/map.html
+
+$(ALECTRYONDIR)/deps.png: deps.dot
+	$(HIDE)mkdir -p $(@D)
+	dot -T png deps.dot > $(ALECTRYONDIR)/deps.png
 
 deps.dot: $(VFILES)
 	$(SHOW)'GENERATE deps.dot'


### PR DESCRIPTION
This sets up a clickable graph for proof movie (Alectryon) documentation. I had to adjust Alectryon file names to fit coqdoc conventions, and work around some bugs in the process.