### PR TITLE
Trace from to rev ind

### DIFF
--- a/VLSM/ByzantineTraces.v
+++ b/VLSM/ByzantineTraces.v
@@ -397,15 +397,12 @@ that <<PreLoadedX>> is included in <<FreeX>>.
         intros.
         split; [|apply H].
         destruct H as [Htr Hs].
-        induction tr using rev_ind.
-        - constructor. apply initial_is_protocol. assumption.
-        - apply finite_protocol_trace_from_app_iff in Htr.
-          destruct Htr as [Htr Hx].
-          specialize (IHtr Htr).
-          apply (finite_protocol_trace_from_app_iff FreeX).
-          split; [assumption|].
-          apply (first_transition_valid FreeX).
-          apply first_transition_valid in Hx.
+        induction Htr using finite_protocol_trace_from_rev_ind.
+        - apply (finite_ptrace_empty FreeX).
+          apply initial_is_protocol; assumption.
+        - specialize (IHHtr Hs) as IHtr; clear IHHtr.
+          apply (extend_right_finite_trace_from FreeX).
+          assumption.
           destruct Hx as [Hvx Htx].
           split; [|assumption].
           apply finite_ptrace_last_pstate in IHtr.
@@ -416,10 +413,10 @@ that <<PreLoadedX>> is included in <<FreeX>>.
           split; [assumption|].
           repeat split; [|apply Hvx].
           destruct Hvx as [Hlst [_ [Hv _]]].
-          destruct x. destruct l as (i, li). simpl in *.
+          destruct l as (i, li). simpl in *.
           specialize (protocol_state_project_preloaded_to_preloaded _ IM constraint lst i Hlst)
             as Hlsti.
-          assert (Hpv : protocol_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (lst i, input)).
+          assert (Hpv : protocol_valid (pre_loaded_with_all_messages_vlsm (IM i)) li (lst i, iom)).
           { split; [assumption|]. split; [|assumption].
             eexists _. apply (pre_loaded_with_all_messages_message_protocol_prop (IM i)).
           }

--- a/VLSM/CBC/FullNode/Validator.v
+++ b/VLSM/CBC/FullNode/Validator.v
@@ -598,26 +598,17 @@ Section proper_sent_received.
     (Hitem : In item prefix)
     : input item = None /\ output item = None /\ destination item = pair [] None /\ l item = None.
   Proof.
-    induction prefix using rev_ind.
+    remember ([],None) as sf in Hprefix.
+    induction Hprefix using @finite_protocol_trace_from_to_rev_ind.
     - inversion Hitem.
     - apply in_app_iff in Hitem.
-      apply finite_protocol_trace_from_to_app_split in Hprefix.
-      destruct Hprefix as [Hprefix Hx].
-      inversion Hx; clear Hx; subst s' f x tl.
-      inversion H3; subst s0 s; clear H3 H.
-      destruct H4 as [_ Ht].
+      subst sf. destruct H as [_ Ht].
       simpl in Ht. unfold vtransition in Ht. simpl in Ht.
-      simpl type in Hprefix.
-      destruct
-        (finite_trace_last start prefix)
-        as (msgs, final) in Hprefix, Ht.
+      destruct s as [msgs final].
       destruct l as [c|];[discriminate Ht|].
       destruct iom as [msg|]; inversion Ht; subst; clear Ht.
       + contradict H0. apply set_add_not_empty.
-      + specialize (IHprefix Hprefix).
-        destruct Hitem as [Hin |[Heq |[]]].
-        * exact (IHprefix Hin).
-        * subst item. simpl. repeat split; reflexivity.
+      + destruct Hitem as [Hin|[<- |[]]];auto.
   Qed.
 
   Lemma last_state_empty_trace

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -1432,6 +1432,34 @@ that include the final state, and give appropriate induction principles.
         apply finite_ptrace_from_to_extend; auto.
     Qed.
 
+    Lemma finite_protocol_trace_from_to_rev_ind
+      (P : state -> state -> list transition_item -> Prop)
+      (Hempty: forall si,
+        protocol_state_prop si -> P si si nil)
+      (Hextend : forall si s tr,
+        P si s tr ->
+        forall sf iom oom l,
+        protocol_transition l (s,iom) (sf,oom) ->
+        P si sf (tr++[{|l:=l; input:=iom; destination:=sf; output:=oom|}])):
+      forall si sf tr,
+        finite_protocol_trace_from_to si sf tr ->
+        P si sf tr.
+    Proof.
+      intros si sf tr Htr.
+      revert sf Htr.
+      induction tr using rev_ind;
+      intros sf Htr.
+      - inversion Htr;subst. apply Hempty;assumption.
+      - apply finite_protocol_trace_from_to_app_split in Htr.
+        destruct Htr as [Htr Hstep].
+        inversion Hstep;subst.
+        inversion H3;subst.
+        revert H4.
+        apply Hextend.
+        apply IHtr.
+        assumption.
+    Qed.
+
 (** *** Infinite [protcol_trace]s *)
 
 (** We now define [infinite_protocol_trace]s. The definitions

--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -1184,6 +1184,50 @@ is equal to the former's last state, it is possible to _concatenate_ them into a
           split;[constructor|];assumption.
     Qed.
 
+    Lemma finite_protocol_trace_from_rev_ind
+      (P : state -> list transition_item -> Prop)
+      (Hempty: forall s,
+        protocol_state_prop s -> P s nil)
+      (Hextend : forall s tr,
+        finite_protocol_trace_from s tr ->
+        P s tr ->
+        forall sf iom oom l
+        (Hx: protocol_transition l (finite_trace_last s tr,iom) (sf,oom)),
+        let x:= {|l:=l; input:=iom; destination:=sf; output:=oom|} in
+        P s (tr++[x])):
+      forall s tr,
+        finite_protocol_trace_from s tr ->
+        P s tr.
+    Proof.
+      induction tr using rev_ind; intro Htr.
+      - inversion Htr. apply Hempty. congruence.
+      - apply finite_protocol_trace_from_app_iff in Htr.
+        destruct Htr as [Htr Hx].
+        destruct x; apply (Hextend _ _ Htr (IHtr Htr)).
+        inversion Hx; congruence.
+    Qed.
+
+    Lemma finite_protocol_trace_rev_ind
+      (P : state -> list transition_item -> Prop)
+      (Hempty: forall si,
+        initial_state_prop si -> P si nil)
+      (Hextend : forall si tr,
+        finite_protocol_trace si tr ->
+        P si tr ->
+        forall sf iom oom l
+        (Hx: protocol_transition l (finite_trace_last si tr,iom) (sf,oom)),
+        let x:= {|l:=l; input:=iom; destination:=sf; output:=oom|} in
+        P si (tr++[x])):
+      forall si tr,
+        finite_protocol_trace si tr ->
+        P si tr.
+    Proof.
+      intros si tr [Htr Hinit].
+      induction Htr using finite_protocol_trace_from_rev_ind.
+      - apply Hempty;auto.
+      - apply Hextend;[split|..];auto.
+    Qed.
+
 (** Several other lemmas in this vein are necessary for proving results regarding
 traces.
 *)
@@ -1781,34 +1825,27 @@ It inherits some previously introduced definitions, culminating with the
         vlsm_run_prop r /\
         start r = is /\ transitions r = tr.
     Proof.
-      induction tr using rev_ind.
-      - exists {| start := is; transitions := []; final := (is, None) |}; simpl; repeat split; try reflexivity.
-        apply empty_run_initial_state. apply (proj2 Htr).
-      - destruct Htr as [Htr Hinit]. apply finite_protocol_trace_from_app_iff in Htr.
-        destruct Htr as [Hprefix Hlst].
-        specialize (IHtr (conj Hprefix Hinit)).
-        destruct IHtr as [r0 [Hr0 [Hstart Htr_r0]]].
-        exists {| start := is; transitions := tr ++ [x]; final := (destination x, output x) |}.
-        simpl. repeat split; try reflexivity.
-        specialize (extend_run r0 Hr0); simpl; intro Hextend.
-        apply finite_ptrace_first_valid_transition in Hlst.
-        destruct x as [lst_l lst_in lst_dest lst_out].
-        simpl in *.
-        specialize (vlsm_run_last_state (exist _ r0 Hr0)); intro Hlast_state.
-        simpl in Hlast_state. rewrite Htr_r0 in Hlast_state.
-        rewrite Hstart in Hlast_state. rewrite Hlast_state in Hlst.
-        specialize (protocol_transition_in Hlst); intro Hmsg.
+      induction Htr using finite_protocol_trace_rev_ind.
+      - exists {| start := si; transitions := []; final := (si, None) |}; simpl; repeat split; try reflexivity.
+        apply empty_run_initial_state. assumption.
+      - destruct Hx as [[_ [Hmsg Hvalid]] Htrans].
+        destruct IHHtr as [r0 [Hr0 [Hstart Htr_r0]]].
+        eexists {| final := (sf,oom)|};simpl;repeat split;[|reflexivity..].
+        specialize (extend_run r0 Hr0); simpl; intros Hextend.
+        replace (fst (final r0)) with (finite_trace_last si tr) in Hextend by
+          (rewrite <- Hstart, <- Htr_r0;
+          apply (vlsm_run_last_state (exist _ r0 Hr0))).
+        rewrite Hstart, Htr_r0 in Hextend.
+        clear Hstart Htr_r0.
         destruct Hmsg as [_s Hmsg].
-        apply protocol_is_run in Hmsg.
-        destruct Hmsg as [[r_msg Hr_msg] Hmsg].
-        specialize (Hextend r_msg Hr_msg lst_l).
-        specialize (protocol_transition_is_valid Hlst); intro Hvalid.
-        simpl in Hmsg. rewrite <- Hmsg in Hextend. simpl  in Hextend.
-        specialize (Hextend Hvalid). rewrite Hstart in Hextend.
-        specialize (protocol_transition_transition Hlst); intro Htransition.
-        rewrite Htransition in Hextend. simpl in Hextend.
-        rewrite Htr_r0 in Hextend.
-        apply Hextend.
+        apply protocol_is_run in Hmsg as [[r_msg Hr_msg] Hmsg].
+        apply (f_equal snd) in Hmsg; simpl in Hmsg.
+        specialize (Hextend r_msg Hr_msg).
+        rewrite <- Hmsg in Hextend.
+        clear _s r_msg Hr_msg Hmsg.
+        specialize (Hextend l1 Hvalid).
+        rewrite Htrans in Hextend.
+        assumption.
     Qed.
 
     Lemma trace_is_protocol_prop
@@ -2375,6 +2412,9 @@ End VLSM.
  *)
 Arguments protocol_state_prop_ind : clear implicits.
 Arguments finite_protocol_trace_from_to_ind : clear implicits.
+
+Arguments finite_protocol_trace_rev_ind : clear implicits.
+Arguments finite_protocol_trace_from_rev_ind : clear implicits.
 
 Arguments extend_right_finite_trace_from [message] (X) [s1] [ts] (Ht12) [l3] [iom3] [s3] [oom3] (Hv23).
 Arguments extend_right_finite_trace_from_to [message] (X) [s1] [s2] [ts] (Ht12) [l3] [iom3] [s3] [oom3] (Hv23).

--- a/VLSM/Plans.v
+++ b/VLSM/Plans.v
@@ -248,24 +248,18 @@ Section protocol_plans.
     (Htr : finite_protocol_trace_from X s tr)
     : fst (apply_plan s (trace_to_plan tr)) = tr.
   Proof.
-    induction tr using rev_ind; try reflexivity.
-    apply finite_protocol_trace_from_app_iff in Htr.
-    destruct Htr as [Htr Hx].
-    specialize (IHtr Htr).
-    setoid_rewrite map_app. rewrite apply_plan_app.
-    specialize (apply_plan_last s (map _transition_item_to_plan_item tr)) as Hlst.
-    destruct (apply_plan s (map _transition_item_to_plan_item tr)) as (aitems, afinal)
-      eqn:Hapl.
-    setoid_rewrite Hapl in IHtr. simpl in IHtr.
+    induction Htr using finite_protocol_trace_from_rev_ind
+    ;[reflexivity|].
+    unfold trace_to_plan, _trace_to_plan.
+    rewrite map_app, apply_plan_app.
+    change (map _ tr) with (trace_to_plan tr).
+    specialize (apply_plan_last s (trace_to_plan tr)) as Hlst.
+    destruct (apply_plan s (trace_to_plan tr))
+      as (sitems,afinal) eqn:Hapl.
     simpl in *. subst.
-    apply first_transition_valid in Hx.
-    destruct Hx as [_ Ht].
-    unfold _transition_item_to_plan_item. simpl. unfold apply_plan, _apply_plan.
+    unfold _transition_item_to_plan_item, apply_plan, _apply_plan.
     simpl.
-    match goal with
-    |- context[vtransition X ?l ?lst] => replace (vtransition X l lst) with (destination x, output x)
-    end.
-    destruct x.
+    replace (vtransition X l _) with (sf,oom) by (symmetry;apply Hx).
     reflexivity.
   Qed.
 

--- a/VLSM/Validating.v
+++ b/VLSM/Validating.v
@@ -141,24 +141,14 @@ Lemma [protocol_message_projection] to show that its conditions are fulfilled.
         apply VLSM_incl_finite_traces_characterization.
         intros.
         split; [|apply H].
-        destruct H as [Htr Hs].
-        induction tr using rev_ind.
-        - constructor. apply initial_is_protocol. assumption.
-        - apply finite_protocol_trace_from_app_iff in Htr.
-          destruct Htr as [Htr Hx].
-          specialize (IHtr Htr).
-          apply (finite_protocol_trace_from_app_iff Xi).
-          split; [assumption|].
-          apply (first_transition_valid Xi).
-          apply first_transition_valid in Hx.
+        induction H using finite_protocol_trace_rev_ind.
+        - apply (finite_ptrace_empty Xi). apply initial_is_protocol. assumption.
+        - apply (extend_right_finite_trace_from Xi);[assumption|].
           destruct Hx as [Hvx Htx].
           split; [|assumption].
-          match goal with
-          |- protocol_valid _ ?l ?siom =>
-            specialize (Hvalidating l siom)
-          end.
-          apply Hvalidating in Hvx.
-          apply projection_valid_protocol. assumption.
+          apply projection_valid_protocol.
+          apply Hvalidating.
+          assumption.
     Qed.
 
 (**


### PR DESCRIPTION
This defines and uses some induction principles in the reverse direction over traces.
This simplifies proofs which previously used `rev_ind` over the trace itself, by avoiding the need to use several tactics and lemmas to decompose the `finite_protocol_trace X s (tr++[x])` assumption to get an induction hypothesis on `tr` and a `protocol_transition` for the transition item `x`.
The main problem is that the `s` and `tr` or `nil` in the subgoals will have types based on `X`, because that is how the type of the induction principle had to be written, which may be inconvenient if the goal is over another VLSM (e.g, `pre_loaded_with_all_messages_vlsm X`).

There was only a single proof using reverse induction on a trace with a `finite_protocol_trace_from_to`, so the first commit is small and maybe we shouldn't even bother with that principle. There are more proofs doing reverse induction over the trace of a `finite_protocol_trace`; the second commit doesn't change them all yet, but should have enough to be good examples.