### PR TITLE
Removing unfold_transition tactic

### DIFF
--- a/VLSM/Common.v
+++ b/VLSM/Common.v
@@ -422,6 +422,8 @@ or [VLSM_type]. Functions [sign] and [type] below achieve this precise purpose.
 
 End vlsm_projections.
 
+Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
+
 Lemma mk_vlsm_machine
   {message : Type}
   (X : VLSM message)

--- a/VLSM/Equivocators/Common.v
+++ b/VLSM/Equivocators/Common.v
@@ -9,6 +9,10 @@ From CasperCBC
     Preamble
     VLSM.Common
     .
+Local Arguments le_lt_dec : simpl never.
+Local Arguments nat_eq_dec : simpl never.
+
+Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 
 (** * VLSM Equivocation
 
@@ -370,7 +374,7 @@ Lemma equivocator_transition_no_equivocation_zero_descriptor
   : snd l = Existing _ 0 false.
 Proof.
   unfold is_singleton_state in Hs'.
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   destruct l as (l, [sn | ei ef]); unfold snd in Ht
   ; [inversion Ht; subst; destruct s; simpl; inversion Hs'|].
   destruct Hv as [Hei _].
@@ -394,7 +398,7 @@ Lemma equivocator_transition_reflects_singleton_state
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
   unfold is_singleton_state.
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   destruct l as (l, [sn | ei ef]); unfold snd in Ht
   ; [inversion Ht; subst; destruct s; simpl; congruence|].
   destruct (le_lt_dec (S (projT1 s)) ei)
@@ -436,7 +440,7 @@ Proof.
     destruct descriptor as [sn| i is_equiv].
     + destruct Hv as [Hsn Hv]. subst om0.
       simpl in x. inversion x. subst. apply IHHbs2.
-    + cbn - [le_lt_dec] in x.
+    + simpl in x.
       destruct Hv as [Hi Hv].
       destruct (le_lt_dec (S (projT1 s)) i); [lia|].
       replace (of_nat_lt l0) with (of_nat_lt Hi) in * by apply of_nat_ext.
@@ -465,7 +469,7 @@ Proof.
     specialize (IHHbs2 X _s om0 eq_refl JMeq_refl).
     specialize (protocol_generated X) as Hgen.
     destruct l as (l, descriptor).
-    cbn - [le_lt_dec] in x.
+    simpl in x.
     destruct descriptor as [sn | i is_equiv].
     + destruct Hv as [Hsn Hv]. subst om0.
       inversion x. subst om.
@@ -547,7 +551,7 @@ Proof.
   - destruct Ht as [[Hps [_ Hv]] Ht].
     simpl in Ht.
     destruct l as (l, description).
-    cbn - [le_lt_dec] in Ht.
+    unfold_vtransition Ht.
     destruct description as [sn| j is_equiv].
     + destruct Hv as [Hsn Hv]. subst om.
       inversion Ht. subst.
@@ -653,7 +657,7 @@ Lemma existing_true_label_equivocator_state_project_not_last
   = equivocator_state_descriptor_project X s (Existing _ ni fi').
 Proof.
   destruct l as (li, ex_true). simpl in Hex_true. subst ex_true.
-  cbn  - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   destruct ( le_lt_dec (S (projT1 s)) ieqvi ); [lia|].
   destruct
     (vtransition X li
@@ -663,7 +667,7 @@ Proof.
   simpl.
   destruct s as (nsi', bsi').
   simpl in Hni.
-  cbn - [le_lt_dec].
+  simpl.
   destruct (le_lt_dec (S (S nsi')) ni); [lia|].
   rewrite to_nat_of_nat.
   destruct (nat_eq_dec ni (S nsi')); [lia|].
@@ -686,7 +690,7 @@ Lemma existing_false_label_equivocator_state_project_not_same
   = equivocator_state_descriptor_project X s (Existing _ ni fi').
 Proof.
   destruct l as (li, ex_false). simpl in Hex_false. subst ex_false.
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   destruct ( le_lt_dec (S (projT1 s)) ieqvi ); [lia|].
   destruct
     (vtransition X li
@@ -694,7 +698,7 @@ Proof.
     as (si'', om'').
   inversion Ht. subst. clear Ht.
   destruct s as (nsi', bsi').
-  cbn - [le_lt_dec].
+  simpl.
   simpl in Hieqvi, l, Hni.
   destruct (le_lt_dec (S nsi') ni); [lia|].
   rewrite eq_dec_if_false; [reflexivity|].

--- a/VLSM/Equivocators/Common.v
+++ b/VLSM/Equivocators/Common.v
@@ -12,8 +12,6 @@ From CasperCBC
 Local Arguments le_lt_dec : simpl never.
 Local Arguments nat_eq_dec : simpl never.
 
-Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
-
 (** * VLSM Equivocation
 
 An [equivocator_vlsm] for a given [VLSM] <<X>> is a VLSM which

--- a/VLSM/Equivocators/Common.v
+++ b/VLSM/Equivocators/Common.v
@@ -351,12 +351,6 @@ Proof.
   assumption.
 Qed.
 
-Local Ltac unfold_transition H :=
-  ( unfold transition in H; unfold equivocator_vlsm in H
-  ; unfold Common.equivocator_vlsm in H
-  ; unfold mk_vlsm in H; unfold machine in H
-  ; unfold projT2 in H; unfold equivocator_vlsm_machine in H
-  ; unfold equivocator_transition in H).
 (* TODO: derive some some simpler lemmas about the equivocator operations,
 or a simpler way of defining the equivocator_transition
 - it's not nice to need to pick apart these cases from inside
@@ -376,7 +370,7 @@ Lemma equivocator_transition_no_equivocation_zero_descriptor
   : snd l = Existing _ 0 false.
 Proof.
   unfold is_singleton_state in Hs'.
-  unfold vtransition in Ht. unfold_transition Ht.
+  cbn - [le_lt_dec] in Ht.
   destruct l as (l, [sn | ei ef]); unfold snd in Ht
   ; [inversion Ht; subst; destruct s; simpl; inversion Hs'|].
   destruct Hv as [Hei _].
@@ -400,7 +394,7 @@ Lemma equivocator_transition_reflects_singleton_state
   : is_singleton_state X s' -> is_singleton_state X s.
 Proof.
   unfold is_singleton_state.
-  unfold vtransition in Ht. unfold_transition Ht.
+  cbn - [le_lt_dec] in Ht.
   destruct l as (l, [sn | ei ef]); unfold snd in Ht
   ; [inversion Ht; subst; destruct s; simpl; congruence|].
   destruct (le_lt_dec (S (projT1 s)) ei)
@@ -442,8 +436,8 @@ Proof.
     destruct descriptor as [sn| i is_equiv].
     + destruct Hv as [Hsn Hv]. subst om0.
       simpl in x. inversion x. subst. apply IHHbs2.
-    + unfold_transition x.
-      unfold snd in x. destruct Hv as [Hi Hv].
+    + cbn - [le_lt_dec] in x.
+      destruct Hv as [Hi Hv].
       destruct (le_lt_dec (S (projT1 s)) i); [lia|].
       replace (of_nat_lt l0) with (of_nat_lt Hi) in * by apply of_nat_ext.
       clear l0.
@@ -470,8 +464,8 @@ Proof.
     destruct IHHbs1 as [_ IHHbs1].
     specialize (IHHbs2 X _s om0 eq_refl JMeq_refl).
     specialize (protocol_generated X) as Hgen.
-    unfold_transition x.
-    destruct l as (l, descriptor). unfold snd in x.
+    destruct l as (l, descriptor).
+    cbn - [le_lt_dec] in x.
     destruct descriptor as [sn | i is_equiv].
     + destruct Hv as [Hsn Hv]. subst om0.
       inversion x. subst om.
@@ -551,13 +545,12 @@ Proof.
     dependent destruction i; [|inversion i].
     assumption.
   - destruct Ht as [[Hps [_ Hv]] Ht].
-    simpl in Ht. unfold vtransition in Ht. unfold_transition Ht.
+    simpl in Ht.
     destruct l as (l, description).
-    unfold snd in Ht.
+    cbn - [le_lt_dec] in Ht.
     destruct description as [sn| j is_equiv].
     + destruct Hv as [Hsn Hv]. subst om.
       inversion Ht. subst.
-      unfold equivocator_state_extend.
       destruct s as (ns, bs).
       simpl in *. destruct (to_nat i) as (ni, Hni).
       destruct (nat_eq_dec ni (S ns)); [|apply IHHbs].
@@ -660,19 +653,17 @@ Lemma existing_true_label_equivocator_state_project_not_last
   = equivocator_state_descriptor_project X s (Existing _ ni fi').
 Proof.
   destruct l as (li, ex_true). simpl in Hex_true. subst ex_true.
-  unfold vtransition in Ht. unfold_transition Ht. unfold snd in Ht.
+  cbn  - [le_lt_dec] in Ht.
   destruct ( le_lt_dec (S (projT1 s)) ieqvi ); [lia|].
   destruct
-    (vtransition X (fst (li, Existing X ieqvi true))
+    (vtransition X li
     (projT2 s (of_nat_lt l), oin))
     as (si'', om'').
   inversion Ht. subst. clear Ht.
-  unfold equivocator_state_descriptor_project.
-  unfold equivocator_state_project.
-  unfold equivocator_state_extend.
-  unfold equivocator_state_extend in Hni.
+  simpl.
   destruct s as (nsi', bsi').
-  unfold projT1 in Hni.
+  simpl in Hni.
+  cbn - [le_lt_dec].
   destruct (le_lt_dec (S (S nsi')) ni); [lia|].
   rewrite to_nat_of_nat.
   destruct (nat_eq_dec ni (S nsi')); [lia|].
@@ -695,19 +686,16 @@ Lemma existing_false_label_equivocator_state_project_not_same
   = equivocator_state_descriptor_project X s (Existing _ ni fi').
 Proof.
   destruct l as (li, ex_false). simpl in Hex_false. subst ex_false.
-  unfold vtransition in Ht. unfold_transition Ht. unfold snd in Ht.
+  cbn - [le_lt_dec] in Ht.
   destruct ( le_lt_dec (S (projT1 s)) ieqvi ); [lia|].
   destruct
-    (vtransition X (fst (li, Existing X ieqvi false))
+    (vtransition X li
     (projT2 s (of_nat_lt l), oin))
     as (si'', om'').
   inversion Ht. subst. clear Ht.
-  unfold equivocator_state_descriptor_project.
-  unfold equivocator_state_project.
   destruct s as (nsi', bsi').
-  simpl in Hieqvi, l.
-  unfold equivocator_state_update in *.
-  unfold projT1 in *.
+  cbn - [le_lt_dec].
+  simpl in Hieqvi, l, Hni.
   destruct (le_lt_dec (S nsi') ni); [lia|].
   rewrite eq_dec_if_false; [reflexivity|].
   intro contra. elim Hnieqvi.

--- a/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -19,7 +19,6 @@ From CasperCBC
 Local Arguments le_lt_dec : simpl never.
 Local Arguments nat_eq_dec : simpl never.
 
-Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 (** * VLSM Equivocator Full Replay Traces *)
 
 Section all_equivocating.

--- a/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -16,6 +16,10 @@ From CasperCBC
     VLSM.Plans
     .
 
+Local Arguments le_lt_dec : simpl never.
+Local Arguments nat_eq_dec : simpl never.
+
+Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 (** * VLSM Equivocator Full Replay Traces *)
 
 Section all_equivocating.
@@ -450,7 +454,8 @@ Proof.
       simpl in Hplan_replay_x.
       inversion Hplan_replay_x. subst. clear Hplan_replay_x. simpl in *.
       rewrite last_error_is_last. simpl.
-      cbn - [le_lt_dec nat_eq_dec] in *.
+      unfold_vtransition Ht_s_epref_i.
+      unfold_vtransition Ht_s_replay_epref_i.
       destruct (IHepref i) as [Hsizei [_ Hstatei]].
       specialize (IHepref eqv). destruct IHepref as [Hsize [_ Hstate]].
       destruct (s_replay_epref i) as (ns_replay_epref_i, bs_replay_epref_i)

--- a/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/FullReplayTraces.v
@@ -43,12 +43,6 @@ Context {message : Type}
   (PreFree := pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM))
   .
 
-Local Ltac unfold_transition Ht :=
-  ( unfold transition, equivocator_IM, Common.equivocator_IM, equivocator_vlsm,
-        mk_vlsm, machine, projT2, equivocator_vlsm_machine, equivocator_transition,
-        snd in Ht
-   ).
-
   (**
   Transforms a [composite_transition_item] of the [equivocator_IM] into
   a [plan_item] for the [equivocators_no_equivocations_vlsm] which is supposed
@@ -456,9 +450,7 @@ Proof.
       simpl in Hplan_replay_x.
       inversion Hplan_replay_x. subst. clear Hplan_replay_x. simpl in *.
       rewrite last_error_is_last. simpl.
-      unfold vtransition in Ht_s_epref_i, Ht_s_replay_epref_i.
-      unfold_transition Ht_s_epref_i.
-      unfold_transition Ht_s_replay_epref_i.
+      cbn - [le_lt_dec nat_eq_dec] in *.
       destruct (IHepref i) as [Hsizei [_ Hstatei]].
       specialize (IHepref eqv). destruct IHepref as [Hsize [_ Hstate]].
       destruct (s_replay_epref i) as (ns_replay_epref_i, bs_replay_epref_i)

--- a/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -20,7 +20,6 @@ From CasperCBC
 Local Arguments le_lt_dec : simpl never.
 Local Arguments nat_eq_dec : simpl never.
 
-Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 (** * VLSM Equivocators Simulating Free Composite *)
 
 Section all_equivocating.

--- a/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -45,11 +45,6 @@ Context {message : Type}
   (PreFree := pre_loaded_with_all_messages_vlsm (free_composite_vlsm equivocator_IM))
   .
 
-Local Ltac unfold_transition  Ht :=
-  ( unfold transition, equivocator_IM, Common.equivocator_IM, equivocator_vlsm
-  , mk_vlsm, machine, projT2, equivocator_vlsm_machine, equivocator_transition
-  in Ht).
-
 Local Ltac unfold_equivocators_transition_item_project :=
 (
   simpl;
@@ -242,8 +237,7 @@ Proof.
     rewrite Heq_eqv. unfold equivocator_vlsm_transition_item_project.
     rewrite state_update_eq.
     destruct str_final_eqv' as (nstr_final_eqv', bstr_final_eqv').
-    unfold vtransition in Ht_tr_final_eqv.
-    unfold_transition Ht_tr_final_eqv. unfold snd in Ht_tr_final_eqv.
+    cbn - [le_lt_dec] in Ht_tr_final_eqv.
     destruct
       (le_lt_dec (S (projT1 (tr_final eqv))) (j_di + S (projT1 (full_replay_state eqv)))).
     * inversion Ht_tr_final_eqv. subst. clear Ht_tr_final_eqv.
@@ -459,7 +453,7 @@ Proof.
     match type of Hesom' with
     | (let (_, _) := ?t in _) = _ => remember t as tesom'
     end.
-    unfold_transition Heqtesom'. unfold snd in Heqtesom'.
+    cbn - [le_lt_dec] in Heqtesom'.
     subst tesom'.
     destruct
       (replayed_trace_from_state_correspondence
@@ -495,7 +489,6 @@ Proof.
     ; [lia|].
     replace (of_nat_lt l) with (of_nat_lt Heqv_merged_descriptors_i) in Hesom' by apply of_nat_ext. clear l.
     rewrite Hstate_state_i in Hesom'.
-    unfold fst in Hesom' at 1.
     specialize (equal_f_dep Hstate_final_project (eqv)) as Hstate_final_project_eqv.
     unfold equivocators_state_project in Hstate_final_project_eqv.
     unfold Common.equivocators_state_project in Hstate_final_project_eqv.
@@ -503,8 +496,9 @@ Proof.
     unfold equivocator_state_project in Hstate_final_project_eqv.
     rewrite Heqv_state_descriptors_eqv in Hstate_final_project_eqv.
     match type of Heqv_state_descriptors_i with
-    | context [projT1 ?s] => destruct s as (n_eqv_state_run_eqv, s_eqv_state_run_eqv) eqn:Heqeqv_state_run_eqv
+    | context [projT1 ?s] => remember s as eqv_state_run_eqv
     end.
+    destruct eqv_state_run_eqv as (n_eqv_state_run_eqv, s_eqv_state_run_eqv).
     simpl in Heqv_state_descriptors_i.
     destruct (le_lt_dec (S n_eqv_state_run_eqv) eqv_state_descriptors_i); [lia|].
     replace (of_nat_lt l) with (of_nat_lt Heqv_state_descriptors_i) in Hstate_final_project_eqv by apply of_nat_ext. clear l.

--- a/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
+++ b/VLSM/Equivocators/Composition/SimulatingFree/SimulatingFree.v
@@ -17,6 +17,10 @@ From CasperCBC
     VLSM.Plans
     .
 
+Local Arguments le_lt_dec : simpl never.
+Local Arguments nat_eq_dec : simpl never.
+
+Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 (** * VLSM Equivocators Simulating Free Composite *)
 
 Section all_equivocating.
@@ -237,7 +241,7 @@ Proof.
     rewrite Heq_eqv. unfold equivocator_vlsm_transition_item_project.
     rewrite state_update_eq.
     destruct str_final_eqv' as (nstr_final_eqv', bstr_final_eqv').
-    cbn - [le_lt_dec] in Ht_tr_final_eqv.
+    unfold_vtransition Ht_tr_final_eqv.
     destruct
       (le_lt_dec (S (projT1 (tr_final eqv))) (j_di + S (projT1 (full_replay_state eqv)))).
     * inversion Ht_tr_final_eqv. subst. clear Ht_tr_final_eqv.
@@ -449,12 +453,7 @@ Proof.
     simpl in Heqv_state_descriptors_i.
     assert (Heqv_t := Hesom').
     unfold vtransition in Hesom'. simpl in Hesom'.
-    unfold vtransition in Hesom'.
-    match type of Hesom' with
-    | (let (_, _) := ?t in _) = _ => remember t as tesom'
-    end.
-    cbn - [le_lt_dec] in Heqtesom'.
-    subst tesom'.
+    unfold_vtransition Hesom'.
     destruct
       (replayed_trace_from_state_correspondence
         IM Hbs index_listing finite_index seed

--- a/VLSM/Equivocators/Projections.v
+++ b/VLSM/Equivocators/Projections.v
@@ -3,6 +3,10 @@ Import ListNotations.
 
 From CasperCBC Require Import Preamble ListExtras VLSM.Common VLSM.Equivocators.Common.
 
+Local Arguments le_lt_dec : simpl never.
+Local Arguments nat_eq_dec : simpl never.
+
+Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 (** * VLSM Projecting Equivocator Traces *)
 
 Section equivocator_vlsm_projections.
@@ -86,7 +90,7 @@ Proof.
   destruct (le_lt_dec (S ndest) 0); [lia|].
   destruct dl as [ndl | idl fdl]
   ; [destruct (nat_eq_dec 1 (S ndest))| destruct fdl; [destruct (nat_eq_dec 1 (S ndest))| destruct (nat_eq_dec idl 0)]]
-  ; simpl in Ht; cbn - [le_lt_dec] in Ht
+  ; simpl in Ht; unfold_vtransition Ht
   ; destruct Hv as [Hidl _].
   - inversion Ht. subst. destruct s; inversion H0. lia.
   - exists None. reflexivity.
@@ -305,7 +309,7 @@ Proof.
     + destruct feqvi; [destruct (nat_eq_dec (S n) (S ni))|destruct (nat_eq_dec ieqvi n)].
       * inversion e. subst ni. clear e.
         eexists _. eexists _. split; [reflexivity|]. split; [repeat split|].
-        -- cbn - [le_lt_dec].
+        -- simpl.
           destruct (le_lt_dec (S n) n); [lia|]. f_equal. apply of_nat_ext.
         -- intros.
           destruct Hv as [Heqv Hv].
@@ -313,13 +317,13 @@ Proof.
           intros.
           simpl in Hsx.
           simpl.
-          cbn - [le_lt_dec] in Ht.
+          unfold_vtransition Ht.
           destruct (le_lt_dec (S (projT1 s)) ieqvi); [lia|].
           replace (of_nat_lt l0) with (of_nat_lt Heqv) in Ht by apply of_nat_ext.
           clear l0.
           assert (Hsxi : sx = projT2 s (of_nat_lt Heqv)).
           { subst.
-            destruct s as (nsi, si). cbn - [le_lt_dec].
+            destruct s as (nsi, si). simpl.
             simpl in Heqv.
             destruct (le_lt_dec (S nsi) ieqvi); [lia|]. 
             f_equal. apply of_nat_ext.
@@ -345,7 +349,7 @@ Proof.
           apply Hv.
         }
         destruct Hv as [Heqv Hv].
-        cbn - [le_lt_dec] in Ht.
+        unfold_vtransition Ht.
         destruct (le_lt_dec (S (projT1 s)) ieqvi); [lia|].
         destruct (vtransition X li (projT2 s (of_nat_lt l0), input))
           as (si', om').
@@ -355,18 +359,18 @@ Proof.
       * subst ieqvi.
         eexists _. eexists _. split; [reflexivity|].
         split; [repeat split|].
-        -- cbn - [le_lt_dec]. 
+        -- simpl.
           destruct (le_lt_dec (S ni) n); [lia|]. f_equal. apply of_nat_ext.
         -- intros.  destruct Hv as [Heqv Hv].
           split; [assumption|].
           intros. simpl.
-          cbn - [le_lt_dec] in Ht.
+          unfold_vtransition Ht.
           destruct (le_lt_dec (S (projT1 s)) n); [lia|].
           replace (of_nat_lt l0) with (of_nat_lt Heqv) in Ht by apply of_nat_ext.
           clear l0.
           assert (Hsxi : sx = projT2 s (of_nat_lt Heqv)).
           { subst.
-            destruct s as (nsi, si). cbn - [le_lt_dec].
+            destruct s as (nsi, si). simpl.
             simpl in Heqv.
             destruct (le_lt_dec (S nsi) n); [lia|].
             f_equal. apply of_nat_ext.
@@ -390,7 +394,7 @@ Proof.
           assumption.
         }
         destruct Hv as [Heqv Hv].
-        cbn - [le_lt_dec] in Ht.
+        unfold_vtransition Ht.
         destruct (le_lt_dec (S (projT1 s)) ieqvi); [lia|].
         destruct (vtransition X li (projT2 s (of_nat_lt l0), input))
           as (si', om').
@@ -574,7 +578,7 @@ Lemma equivocator_protocol_transition_item_project_inv2
 Proof.
   destruct l as (lx, descriptor).
   destruct s as (ns, bs).
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   unfold equivocator_vlsm_transition_item_project in Hitem.
   destruct di as [sn| i fi]; [congruence|].
   exists i. exists fi. exists eq_refl. unfold item in Hitem.
@@ -640,7 +644,7 @@ Lemma equivocator_protocol_transition_item_project_inv3
     end.
 Proof.
   destruct l as (lx, d).
-  cbn -[le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   unfold equivocator_vlsm_transition_item_project in Hitem.
   destruct di as [si | i fi]; [inversion Hitem; reflexivity|].
   unfold item in Hitem.
@@ -666,7 +670,7 @@ Proof.
   - destruct Hv as [Hj Hv].
     destruct (le_lt_dec (S (projT1 s')) id); [lia|].
     replace (of_nat_lt l0) with (of_nat_lt Hj) in Ht by apply of_nat_ext. clear l0.
-    destruct s' as (n', bs'). cbn - [nat_eq_dec] in *.
+    destruct s' as (n', bs'). simpl in *.
     destruct (vtransition X lx (bs' (of_nat_lt Hj), iom))
       as (si', om') eqn:Htx.
     destruct fd as [|].
@@ -708,20 +712,20 @@ Lemma equivocator_protocol_transition_item_project_inv4
 Proof.
   unfold equivocator_vlsm_transition_item_project.
   destruct l as (lx, descriptor).
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   destruct s as (ns, bs).
   destruct s' as (n', bs').
   destruct descriptor as [sn | j is_equiv].
   - simpl in Ht.
     inversion Ht. subst. clear Ht. simpl_existT.
-    cbn - [le_lt_dec nat_eq_dec].
+    simpl.
     simpl in Hi'.
     assert (Hi'' : i' < S (S n')) by lia.
     exists Hi''.
     destruct (le_lt_dec (S (S n')) i'); [lia |]. clear l.
     rewrite eq_dec_if_false; [|lia].
     exists false. exists None. reflexivity.
-  - destruct Hv as [Hj Hv]. cbn - [le_lt_dec] in Ht.
+  - destruct Hv as [Hj Hv]. simpl in Ht.
     simpl in Hj.
     destruct (le_lt_dec (S n') j); [lia|].
     replace (of_nat_lt l) with (of_nat_lt Hj) in Ht by apply of_nat_ext. clear l.
@@ -764,12 +768,12 @@ Proof.
   unfold equivocator_vlsm_transition_item_project.
   destruct s as (ns, bs).
   destruct s' as (ns', bs').
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   destruct l as (lx, d).
   simpl in Hnew. subst d.
   inversion Ht. subst. clear Ht.
   simpl_existT.
-  exists (S ns'). cbn - [le_lt_dec nat_eq_dec]. split; [lia|].
+  exists (S ns'). simpl. split; [lia|].
   destruct (le_lt_dec (S (S ns')) (S ns')); [lia|].
   rewrite eq_dec_if_true; reflexivity.
 Qed.
@@ -795,9 +799,9 @@ Proof.
   destruct s as (ns, bs).
   destruct s' as (ns', bs').
   destruct l as (lx, d).
-  cbn - [le_lt_dec] in Ht.
+  unfold_vtransition Ht.
   simpl in Hsndl. subst d.
-  cbn - [le_lt_dec nat_eq_dec].
+  simpl.
   destruct Hv as [Hi Hv]. simpl in Hi.
   destruct (le_lt_dec (S ns') i); [lia|].
   replace (of_nat_lt l) with (of_nat_lt Hi) in Ht by apply of_nat_ext. clear l.

--- a/VLSM/Equivocators/Projections.v
+++ b/VLSM/Equivocators/Projections.v
@@ -6,7 +6,6 @@ From CasperCBC Require Import Preamble ListExtras VLSM.Common VLSM.Equivocators.
 Local Arguments le_lt_dec : simpl never.
 Local Arguments nat_eq_dec : simpl never.
 
-Local Ltac unfold_vtransition H := (unfold vtransition in H; simpl in H).
 (** * VLSM Projecting Equivocator Traces *)
 
 Section equivocator_vlsm_projections.

--- a/VLSM/Equivocators/Projections.v
+++ b/VLSM/Equivocators/Projections.v
@@ -26,13 +26,6 @@ Context
   (MachineDescriptor := MachineDescriptor X)
   .
 
-Local Ltac unfold_transition H :=
-  ( unfold transition in H; unfold equivocator_vlsm in H
-  ; unfold Common.equivocator_vlsm in H
-  ; unfold mk_vlsm in H; unfold machine in H
-  ; unfold projT2 in H; unfold equivocator_vlsm_machine in H
-  ; unfold equivocator_transition in H).
-
 (** Given a [transition_item] <<item>> for the [equivocator_vlsm] and a
 [MachineDescriptor] referring to a position in the [destination] of <<item>>,
 it returns a transition item for the original machine (if the descriptor
@@ -93,7 +86,7 @@ Proof.
   destruct (le_lt_dec (S ndest) 0); [lia|].
   destruct dl as [ndl | idl fdl]
   ; [destruct (nat_eq_dec 1 (S ndest))| destruct fdl; [destruct (nat_eq_dec 1 (S ndest))| destruct (nat_eq_dec idl 0)]]
-  ; simpl in Ht; unfold vtransition in Ht; unfold_transition Ht; unfold snd in Ht
+  ; simpl in Ht; cbn - [le_lt_dec] in Ht
   ; destruct Hv as [Hidl _].
   - inversion Ht. subst. destruct s; inversion H0. lia.
   - exists None. reflexivity.
@@ -306,35 +299,29 @@ Proof.
           simpl. lia.
         }
         simpl.
-        unfold vtransition in Ht. unfold_transition Ht. unfold snd in Ht.
         inversion Ht. subst. clear Ht.
-        destruct s as (neqv, seqv). simpl in *. inversion H0.
-        subst ni. lia.
+        destruct s as (neqv, seqv). inversion H0.
+        subst ni. simpl. lia.
     + destruct feqvi; [destruct (nat_eq_dec (S n) (S ni))|destruct (nat_eq_dec ieqvi n)].
       * inversion e. subst ni. clear e.
         eexists _. eexists _. split; [reflexivity|]. split; [repeat split|].
-        -- unfold equivocator_state_descriptor_project.
-          unfold equivocator_state_project.
-          destruct (le_lt_dec (S n) n); [lia|]. simpl. f_equal. apply of_nat_ext.
+        -- cbn - [le_lt_dec].
+          destruct (le_lt_dec (S n) n); [lia|]. f_equal. apply of_nat_ext.
         -- intros.
           destruct Hv as [Heqv Hv].
           split; [assumption|].
           intros.
-          unfold equivocator_state_descriptor_project in Hsx.
-          unfold equivocator_state_project in Hsx.
+          simpl in Hsx.
           simpl.
-          unfold fst in Hv.
-          unfold vvalid in Hv.
-          unfold vtransition in Ht.
-          unfold_transition Ht. unfold snd in Ht.
+          cbn - [le_lt_dec] in Ht.
           destruct (le_lt_dec (S (projT1 s)) ieqvi); [lia|].
-          replace (of_nat_lt l0) with (of_nat_lt Heqv) in * by apply of_nat_ext.
+          replace (of_nat_lt l0) with (of_nat_lt Heqv) in Ht by apply of_nat_ext.
           clear l0.
           assert (Hsxi : sx = projT2 s (of_nat_lt Heqv)).
           { subst.
-            destruct s as (nsi, si). unfold projT2.
+            destruct s as (nsi, si). cbn - [le_lt_dec].
             simpl in Heqv.
-            destruct (le_lt_dec (S nsi) ieqvi); [lia|].
+            destruct (le_lt_dec (S nsi) ieqvi); [lia|]. 
             f_equal. apply of_nat_ext.
           }
           rewrite Hsxi. split; [assumption|].
@@ -358,40 +345,33 @@ Proof.
           apply Hv.
         }
         destruct Hv as [Heqv Hv].
-        unfold vtransition in Ht. unfold_transition Ht. unfold snd in Ht.
+        cbn - [le_lt_dec] in Ht.
         destruct (le_lt_dec (S (projT1 s)) ieqvi); [lia|].
-        destruct (vtransition X (fst (li, Existing X ieqvi true))
-        (projT2 s (of_nat_lt l0), input))
+        destruct (vtransition X li (projT2 s (of_nat_lt l0), input))
           as (si', om').
         inversion Ht. subst.
-        destruct s as (neqv, seqv). simpl in *.
-        inversion H0. subst ni. lia.
+        destruct s as (neqv, seqv).
+        inversion H0. subst ni. simpl. lia.
       * subst ieqvi.
         eexists _. eexists _. split; [reflexivity|].
         split; [repeat split|].
-        -- unfold equivocator_state_descriptor_project.
-          unfold equivocator_state_project.
-          destruct (le_lt_dec (S ni) n); [lia|]. simpl. f_equal. apply of_nat_ext.
+        -- cbn - [le_lt_dec]. 
+          destruct (le_lt_dec (S ni) n); [lia|]. f_equal. apply of_nat_ext.
         -- intros.  destruct Hv as [Heqv Hv].
           split; [assumption|].
           intros. simpl.
-          unfold equivocator_state_descriptor_project in Hsx.
-          unfold equivocator_state_project in Hsx.
-          unfold fst in Hv.
-          unfold vvalid in Hv.
-          unfold vtransition in Ht. unfold_transition Ht. unfold snd in Ht.
+          cbn - [le_lt_dec] in Ht.
           destruct (le_lt_dec (S (projT1 s)) n); [lia|].
-          replace (of_nat_lt l0) with (of_nat_lt Heqv) in * by apply of_nat_ext.
+          replace (of_nat_lt l0) with (of_nat_lt Heqv) in Ht by apply of_nat_ext.
           clear l0.
           assert (Hsxi : sx = projT2 s (of_nat_lt Heqv)).
           { subst.
-            destruct s as (nsi, si). unfold projT2.
+            destruct s as (nsi, si). cbn - [le_lt_dec].
             simpl in Heqv.
             destruct (le_lt_dec (S nsi) n); [lia|].
             f_equal. apply of_nat_ext.
           }
           rewrite Hsxi. split; [assumption|].
-          unfold fst in Ht.
           destruct (vtransition X li (projT2 s (of_nat_lt Heqv), input))
             as (si'', om') eqn:Ht'.
           inversion Ht. clear Ht. subst ni.
@@ -410,9 +390,8 @@ Proof.
           assumption.
         }
         destruct Hv as [Heqv Hv].
-        unfold vtransition in Ht. unfold_transition Ht. unfold snd in Ht.
+        cbn - [le_lt_dec] in Ht.
         destruct (le_lt_dec (S (projT1 s)) ieqvi); [lia|].
-        unfold fst in Ht.
         destruct (vtransition X li (projT2 s (of_nat_lt l0), input))
           as (si', om').
         inversion Ht. subst. simpl. lia.
@@ -593,22 +572,19 @@ Lemma equivocator_protocol_transition_item_project_inv2
     vvalid X (fst l) (s'x, iom) /\
     vtransition X (fst l) (s'x, iom) = (sx, oom).
 Proof.
-  unfold vvalid in Hv. unfold vtransition in Ht.
-  unfold_transition Ht.
-  simpl in Hv.
+  destruct l as (lx, descriptor).
+  destruct s as (ns, bs).
+  cbn - [le_lt_dec] in Ht.
   unfold equivocator_vlsm_transition_item_project in Hitem.
   destruct di as [sn| i fi]; [congruence|].
   exists i. exists fi. exists eq_refl. unfold item in Hitem.
-  destruct l as (lx, descriptor).
-  destruct s as (ns, bs).
   destruct (le_lt_dec (S ns) i); [congruence|].
-  exists l. unfold snd in Ht. unfold snd in Hv.
+  exists l.
   destruct descriptor as [sn| j is_equiv].
   - destruct (nat_eq_dec (S i) (S ns)); congruence.
   - destruct Hv as [Hj Hv].
     destruct (le_lt_dec (S (projT1 s')) j); [lia|].
-    replace (of_nat_lt l0) with (of_nat_lt Hj) in * by apply of_nat_ext. clear l0.
-    simpl in Ht.
+    replace (of_nat_lt l0) with (of_nat_lt Hj) in Ht by apply of_nat_ext. clear l0.
     destruct (vtransition X lx (projT2 s' (of_nat_lt Hj), iom))
       as (si', om') eqn:Htx.
     destruct s' as (n', bs').
@@ -663,12 +639,11 @@ Lemma equivocator_protocol_transition_item_project_inv3
       end
     end.
 Proof.
-  unfold vvalid in Hv. unfold vtransition in Ht.
   destruct l as (lx, d).
-  simpl in Hv. unfold_transition Ht. unfold snd in Ht.
+  cbn -[le_lt_dec] in Ht.
   unfold equivocator_vlsm_transition_item_project in Hitem.
   destruct di as [si | i fi]; [inversion Hitem; reflexivity|].
-  simpl in Hv. unfold item in Hitem.
+  unfold item in Hitem.
   destruct s as (ns, bs).
   destruct (le_lt_dec (S ns) i); [congruence|].
   destruct d as [sd | id fd].
@@ -690,18 +665,14 @@ Proof.
       f_equal. apply of_nat_ext.
   - destruct Hv as [Hj Hv].
     destruct (le_lt_dec (S (projT1 s')) id); [lia|].
-    replace (of_nat_lt l0) with (of_nat_lt Hj) in * by apply of_nat_ext. clear l0.
-    destruct s' as (n', bs'). simpl in Hv. unfold projT2 in Ht. simpl in Hj.
-    simpl in Ht.
-    destruct
-      (@vtransition message X lx
-      (@pair (@vstate message X) (option message)
-         (bs' (@of_nat_lt id (S n') Hj)) iom))
+    replace (of_nat_lt l0) with (of_nat_lt Hj) in Ht by apply of_nat_ext. clear l0.
+    destruct s' as (n', bs'). cbn - [nat_eq_dec] in *.
+    destruct (vtransition X lx (bs' (of_nat_lt Hj), iom))
       as (si', om') eqn:Htx.
     destruct fd as [|].
     + destruct (nat_eq_dec (S i) (S ns)); [congruence|].
       inversion Hitem. subst di'. clear Hitem.
-      simpl. exists l. inversion Ht. subst.
+      exists l. inversion Ht. subst.
       assert (Hi' : i < S n') by lia.
       exists Hi'.
       simpl_existT. subst.
@@ -710,7 +681,7 @@ Proof.
       f_equal.
       apply of_nat_ext.
     + destruct (nat_eq_dec id i); [congruence|].
-      inversion Hitem. subst di'. clear Hitem. simpl.
+      inversion Hitem. subst di'. clear Hitem.
       exists l. inversion Ht. subst. exists l.
       simpl_existT. subst.
       rewrite eq_dec_if_false; [reflexivity|].
@@ -735,27 +706,25 @@ Lemma equivocator_protocol_transition_item_project_inv4
     (item := {| l := l; input := iom; destination := s; output := oom |}),
     equivocator_vlsm_transition_item_project item (Existing _ i' fi') = Some (oitem, Existing _ i' fi'').
 Proof.
-  unfold vvalid in Hv. unfold vtransition in Ht.
-  simpl in Hv. unfold_transition Ht. unfold equivocator_vlsm_transition_item_project.
-  destruct l as (lx, descriptor). simpl in Hv. unfold snd in Ht.
+  unfold equivocator_vlsm_transition_item_project.
+  destruct l as (lx, descriptor).
+  cbn - [le_lt_dec] in Ht.
   destruct s as (ns, bs).
   destruct s' as (n', bs').
   destruct descriptor as [sn | j is_equiv].
   - simpl in Ht.
     inversion Ht. subst. clear Ht. simpl_existT.
-    unfold projT1.
+    cbn - [le_lt_dec nat_eq_dec].
     simpl in Hi'.
     assert (Hi'' : i' < S (S n')) by lia.
     exists Hi''.
-    destruct (le_lt_dec (S (S n')) i'). { lia. }
-    replace (of_nat_lt l) with (of_nat_lt Hi'') in * by apply of_nat_ext. clear l.
-    rewrite eq_dec_if_false.
-    + exists false. exists None. reflexivity.
-    + lia.
-  - destruct Hv as [Hj Hv]. unfold projT1 in Ht. simpl in Hj.
+    destruct (le_lt_dec (S (S n')) i'); [lia |]. clear l.
+    rewrite eq_dec_if_false; [|lia].
+    exists false. exists None. reflexivity.
+  - destruct Hv as [Hj Hv]. cbn - [le_lt_dec] in Ht.
+    simpl in Hj.
     destruct (le_lt_dec (S n') j); [lia|].
-    replace (of_nat_lt l) with (of_nat_lt Hj) in * by apply of_nat_ext. clear l.
-    simpl in Ht.
+    replace (of_nat_lt l) with (of_nat_lt Hj) in Ht by apply of_nat_ext. clear l.
     destruct (vtransition X lx (bs' (of_nat_lt Hj), iom))
       as (si', om') eqn:Htx.
     simpl in Hi'.
@@ -795,14 +764,12 @@ Proof.
   unfold equivocator_vlsm_transition_item_project.
   destruct s as (ns, bs).
   destruct s' as (ns', bs').
-  unfold vtransition in Ht. unfold_transition Ht.
-  unfold vvalid in Hv. simpl in Hv.
-  destruct l as (lx, d). unfold snd in Ht. simpl in Hv.
+  cbn - [le_lt_dec] in Ht.
+  destruct l as (lx, d).
   simpl in Hnew. subst d.
-  inversion Ht. subst; clear Ht.
+  inversion Ht. subst. clear Ht.
   simpl_existT.
-  exists (S ns').  split; [simpl; lia|].
-  unfold snd. unfold item.
+  exists (S ns'). cbn - [le_lt_dec nat_eq_dec]. split; [lia|].
   destruct (le_lt_dec (S (S ns')) (S ns')); [lia|].
   rewrite eq_dec_if_true; reflexivity.
 Qed.
@@ -827,15 +794,13 @@ Proof.
   unfold equivocator_vlsm_transition_item_project.
   destruct s as (ns, bs).
   destruct s' as (ns', bs').
-  unfold vtransition in Ht. unfold_transition Ht.
-  unfold vvalid in Hv. simpl in Hv.
-  destruct l as (lx, d). unfold snd in Ht. simpl in Hv.
+  destruct l as (lx, d).
+  cbn - [le_lt_dec] in Ht.
   simpl in Hsndl. subst d.
-  unfold snd. unfold item. destruct Hv as [Hi Hv].
-  unfold projT1 in Ht.
+  cbn - [le_lt_dec nat_eq_dec].
+  destruct Hv as [Hi Hv]. simpl in Hi.
   destruct (le_lt_dec (S ns') i); [lia|].
-  replace (of_nat_lt l) with (of_nat_lt Hi) in * by apply of_nat_ext. clear l.
-  simpl in Ht.
+  replace (of_nat_lt l) with (of_nat_lt Hi) in Ht by apply of_nat_ext. clear l.
   destruct (vtransition X lx (bs' (of_nat_lt Hi), iom)) as (sn', om').
   destruct is_equiv as [|]; inversion Ht; subst; clear Ht; apply inj_pairT2 in H1; subst.
   + exists (S ns'). split; [simpl; lia|].


### PR DESCRIPTION
I replaced `unfold_transition` with `cbn - [le_lt_dec]`. Seems to work fine. However, I would like to mention that the way we're set up with using `lia` to solve our arithmetic constraints, we probably never want to expand arithmetic; hence, something like a hint to prevent unfolding things like `le_lt_dec` and `nat_eq_dec` would work even better than my current setup.